### PR TITLE
Add meta linter golangci-lint

### DIFF
--- a/.github/workflows/report.yaml
+++ b/.github/workflows/report.yaml
@@ -1,6 +1,12 @@
 name: Multilinters
 
-on: [push, pull_request]
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+  pull_request:
 
 jobs:
 

--- a/.github/workflows/report.yaml
+++ b/.github/workflows/report.yaml
@@ -1,0 +1,20 @@
+name: Multilinters
+
+on: [push]
+
+jobs:
+
+  build:
+    name: Check code
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v1
+        with:
+          version: v1.27
+          args: -E gosec,goconst,nestif,interfacer,bodyclose,rowserrcheck
+          only-new-issues: true

--- a/.github/workflows/report.yaml
+++ b/.github/workflows/report.yaml
@@ -1,6 +1,6 @@
 name: Multilinters
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
 


### PR DESCRIPTION
Add workflow using https://github.com/marketplace/actions/run-golangci-lint to provide multilinting.

Runs with `only-new-issues` to not annotate old code on PR (newish feature that may not behave correctly).