### PR TITLE
Fix S3 upload function

### DIFF
--- a/cmd/ingest/ingest.go
+++ b/cmd/ingest/ingest.go
@@ -84,7 +84,7 @@ func main() {
 				// This should really be hadled by the DB retry mechanism
 			}
 
-			file, err := inbox.ReadFile(message.FilePath)
+			file, err := inbox.NewFileReader(message.FilePath)
 			if err != nil {
 				log.Errorf("Failed to open file: %s, reason: %v", message.FilePath, err)
 				continue

--- a/cmd/ingest/ingest.go
+++ b/cmd/ingest/ingest.go
@@ -109,7 +109,7 @@ func main() {
 
 			// Create a random uuid as file name
 			archivedFile := uuid.New().String()
-			dest, err := archive.WriteFile(archivedFile)
+			dest, err := archive.NewFileWriter(archivedFile)
 			if err != nil {
 				log.Errorf("Failed to create file: %s, reason: %v", archivedFile, err)
 				continue

--- a/cmd/ingest/ingest.go
+++ b/cmd/ingest/ingest.go
@@ -174,6 +174,7 @@ func main() {
 				}
 			}
 
+			dest.Close()
 			log.Debugln("Mark as archived")
 			fileInfo := postgres.FileInfo{}
 			fileInfo.Checksum = fmt.Sprintf("%x", hash.Sum(nil))

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -111,7 +111,7 @@ func main() {
 				log.Error(err)
 			}
 
-			f, err := backend.ReadFile(message.ArchivePath)
+			f, err := backend.NewFileReader(message.ArchivePath)
 			if err != nil {
 				log.Errorf("Failed to open file: %s, reason: %v", message.ArchivePath, err)
 				continue

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -26,7 +26,7 @@ import (
 type Backend interface {
 	GetFileSize(filePath string) (int64, error)
 	ReadFile(filePath string) (io.Reader, error)
-	WriteFile(filePath string) (io.WriteCloser, error)
+	NewFileWriter(filePath string) (io.WriteCloser, error)
 }
 
 // PosixBackend encapsulates an io.Reader instance
@@ -59,8 +59,8 @@ func (pb *PosixBackend) ReadFile(filePath string) (io.Reader, error) {
 	return file, nil
 }
 
-// WriteFile returns an io.Writer instance
-func (pb *PosixBackend) WriteFile(filePath string) (io.WriteCloser, error) {
+// NewFileWriter returns an io.Writer instance
+func (pb *PosixBackend) NewFileWriter(filePath string) (io.WriteCloser, error) {
 	file, err := os.OpenFile(filepath.Join(filepath.Clean(pb.Location), filePath), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0640)
 	if err != nil {
 		log.Error(err)
@@ -148,8 +148,8 @@ func (sb *S3Backend) ReadFile(filePath string) (io.Reader, error) {
 	return bytes.NewReader(buf.Bytes()), nil
 }
 
-// WriteFile uploads the contents of an io.Reader to a S3 bucket
-func (sb *S3Backend) WriteFile(filePath string) (io.WriteCloser, error) {
+// NewFileWriter uploads the contents of an io.Reader to a S3 bucket
+func (sb *S3Backend) NewFileWriter(filePath string) (io.WriteCloser, error) {
 	reader, writer := io.Pipe()
 	go func() {
 		_, err := sb.Uploader.Upload(&s3manager.UploadInput{

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -25,7 +25,7 @@ import (
 // Backend defines methods to be implemented by PosixBackend and S3Backend
 type Backend interface {
 	GetFileSize(filePath string) (int64, error)
-	ReadFile(filePath string) (io.Reader, error)
+	NewFileReader(filePath string) (io.Reader, error)
 	NewFileWriter(filePath string) (io.WriteCloser, error)
 }
 
@@ -48,8 +48,8 @@ func NewPosixBackend(c PosixConf) *PosixBackend {
 	return &PosixBackend{FileReader: reader, Location: c.Location}
 }
 
-// ReadFile returns an io.Reader instance
-func (pb *PosixBackend) ReadFile(filePath string) (io.Reader, error) {
+// NewFileReader returns an io.Reader instance
+func (pb *PosixBackend) NewFileReader(filePath string) (io.Reader, error) {
 	file, err := os.Open(filepath.Join(filepath.Clean(pb.Location), filePath))
 	if err != nil {
 		log.Error(err)
@@ -131,8 +131,8 @@ func NewS3Backend(c S3Conf) *S3Backend {
 		Client: s3.New(session)}
 }
 
-// ReadFile returns an io.Reader instance
-func (sb *S3Backend) ReadFile(filePath string) (io.Reader, error) {
+// NewFileReader returns an io.Reader instance
+func (sb *S3Backend) NewFileReader(filePath string) (io.Reader, error) {
 	buf := new(aws.WriteAtBuffer)
 	_, err := sb.Downloader.Download(buf,
 		&s3.GetObjectInput{


### PR DESCRIPTION
For the S3 uploader to work we need to wrap it in a go routine and we must explicitly close the writer one we are done.