### PR TITLE
Storage cleanup

### DIFF
--- a/cmd/ingest/ingest.go
+++ b/cmd/ingest/ingest.go
@@ -99,8 +99,8 @@ func main() {
 			// 4MiB readbuffer, this must be large enough that we get the entire header and the first 64KiB datablock
 			// Should be made configurable once we have S3 support
 			var bufSize int
-			if bufSize = 4 * 1024 * 1024; conf.InboxS3.Chunksize > 4*1024*1024 {
-				bufSize = conf.InboxS3.Chunksize
+			if bufSize = 4 * 1024 * 1024; conf.Inbox.S3.Chunksize > 4*1024*1024 {
+				bufSize = conf.Inbox.S3.Chunksize
 			}
 			readBuffer := make([]byte, bufSize)
 			hash := sha256.New()

--- a/cmd/ingest/ingest.go
+++ b/cmd/ingest/ingest.go
@@ -47,7 +47,6 @@ func main() {
 	if err != nil {
 		log.Println("err:", err)
 	}
-	var archive, inbox storage.Backend
 
 	defer mq.Channel.Close()
 	defer mq.Connection.Close()
@@ -60,18 +59,9 @@ func main() {
 
 	go func() {
 		for delivered := range broker.GetMessages(mq, conf.Broker.Queue) {
-			if conf.ArchiveType == "s3" {
-				archive = storage.NewS3Backend(conf.ArchiveS3)
-			} else {
-				archive = storage.NewPosixBackend(conf.ArchivePosix)
-			}
 
-			if conf.InboxType == "s3" {
-				inbox = storage.NewS3Backend(conf.InboxS3)
-
-			} else {
-				inbox = storage.NewPosixBackend(conf.InboxPosix)
-			}
+			archive := storage.NewBackend(conf.Archive)
+			inbox := storage.NewBackend(conf.Inbox)
 
 			log.Debugf("Received a message: %s", delivered.Body)
 			if err := json.Unmarshal(delivered.Body, &message); err != nil {

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -49,13 +49,7 @@ func main() {
 		log.Println("err:", err)
 	}
 
-	// Storage logici for S3 or Posix
-	var backend storage.Backend
-	if conf.ArchiveType == "posix" {
-		backend = storage.NewPosixBackend(conf.ArchivePosix)
-	} else {
-		backend = storage.NewS3Backend(conf.ArchiveS3)
-	}
+	backend := storage.NewBackend(conf.Archive)
 
 	defer mq.Channel.Close()
 	defer mq.Connection.Close()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,15 +23,11 @@ var (
 
 // Config is a parent object for all the different configuration parts
 type Config struct {
-	ArchiveType  string
-	ArchiveS3    storage.S3Conf
-	ArchivePosix storage.PosixConf
-	Broker       broker.Mqconf
-	Crypt4gh     Crypt4gh
-	InboxType    string
-	InboxS3      storage.S3Conf
-	InboxPosix   storage.PosixConf
-	Postgres     postgres.Pgconf
+	Archive  storage.Conf
+	Broker   broker.Mqconf
+	Crypt4gh Crypt4gh
+	Inbox    storage.Conf
+	Postgres postgres.Pgconf
 }
 
 // Crypt4gh holds c4gh related config info
@@ -170,28 +166,22 @@ func configS3Storage(prefix string) storage.S3Conf {
 
 func (c *Config) configArchive() {
 	if viper.GetString("archive.type") == "s3" {
-		c.ArchiveType = "s3"
-		c.ArchiveS3 = configS3Storage("archive")
+		c.Archive.Type = "s3"
+		c.Archive.S3 = configS3Storage("archive")
 	} else {
-		file := storage.PosixConf{}
-		file.Location = viper.GetString("archive.location")
-
-		c.ArchiveType = "posix"
-		c.ArchivePosix = file
+		c.Archive.Type = "posix"
+		c.Archive.Posix.Location = viper.GetString("archive.location")
 	}
 }
 
 func (c *Config) configInbox() {
 
 	if viper.GetString("inbox.type") == "s3" {
-		c.InboxType = "s3"
-		c.InboxS3 = configS3Storage("inbox")
+		c.Inbox.Type = "s3"
+		c.Inbox.S3 = configS3Storage("inbox")
 	} else {
-		file := storage.PosixConf{}
-		file.Location = viper.GetString("inbox.location")
-
-		c.InboxType = "Posix"
-		c.InboxPosix = file
+		c.Inbox.Type = "Posix"
+		c.Inbox.Posix.Location = viper.GetString("inbox.location")
 	}
 }
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -47,10 +47,18 @@ type posixConf struct {
 	Location string
 }
 
-// NewPosixBackend returns a PosixReader struct
-func NewPosixBackend(c PosixConf) *PosixBackend {
-	var reader io.Reader
-	return &PosixBackend{FileReader: reader, Location: c.Location}
+// NewBackend initates a storage backend
+func NewBackend(c Conf) Backend {
+	switch c.Type {
+	case "s3":
+		return newS3Backend(c.S3)
+	default:
+		return newPosixBackend(c.Posix)
+	}
+}
+
+func newPosixBackend(c posixConf) *posixBackend {
+	return &posixBackend{Location: c.Location}
 }
 
 // NewFileReader returns an io.Reader instance

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -39,7 +39,6 @@ type posixBackend struct {
 	FileReader io.Reader
 	FileWriter io.Writer
 	Location   string
-	Size       int64
 }
 
 type posixConf struct {
@@ -95,10 +94,8 @@ func (pb *posixBackend) GetFileSize(filePath string) (int64, error) {
 
 type s3Backend struct {
 	Client   *s3.S3
-	Client     *s3.S3
-	Downloader *s3manager.Downloader
-	Uploader   *s3manager.Uploader
-	Bucket     string
+	Uploader *s3manager.Uploader
+	Bucket   string
 }
 
 // S3Conf stores information about the S3 storage backend
@@ -134,10 +131,6 @@ func newS3Backend(c S3Conf) *s3Backend {
 			u.PartSize = int64(c.Chunksize)
 			u.Concurrency = c.UploadConcurrency
 			u.LeavePartsOnError = false
-		}),
-		Downloader: s3manager.NewDownloader(session, func(d *s3manager.Downloader) {
-			d.PartSize = int64(c.Chunksize)
-			d.Concurrency = 1
 		}),
 		Client: s3.New(session)}
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -28,6 +28,13 @@ type Backend interface {
 	NewFileWriter(filePath string) (io.WriteCloser, error)
 }
 
+// Conf is a wrapper for the storage config
+type Conf struct {
+	Type  string
+	S3    S3Conf
+	Posix posixConf
+}
+
 // PosixBackend encapsulates an io.Reader instance
 type PosixBackend struct {
 	FileReader io.Reader
@@ -36,8 +43,7 @@ type PosixBackend struct {
 	Size       int64
 }
 
-// PosixConf stores information about the POSIX storage backend
-type PosixConf struct {
+type posixConf struct {
 	Location string
 }
 


### PR DESCRIPTION
Reworks the storage config and initiation so we don't have to use any if/else statements on the main code.
The new init format is simply : 
```go 
archive := storage.NewBackend(conf.Archive)
```
Where `Archive` is the storage config struct
```go
type Conf struct {
	Type  string
	S3    S3Conf
	Posix posixConf
}
```

Fixes: #23 