### PR TITLE
Dockerfile fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ LABEL org.label-schema.vcs-url="https://github.com/neicnordic/sda-pipeline"
 LABEL org.label-schema.vcs-ref=$SOURCE_COMMIT
 
 COPY --from=builder /go/passwd /etc/passwd
-COPY --from=builder /go/sda-* /
+COPY --from=builder /go/sda-* /bin/
 COPY --from=builder /go/schemas /schemas
 
 USER 65534

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,6 @@ LABEL org.label-schema.vcs-ref=$SOURCE_COMMIT
 
 COPY --from=builder /go/passwd /etc/passwd
 COPY --from=builder /go/sda-* /
+COPY --from=builder /go/schemas /schemas
 
 USER 65534


### PR DESCRIPTION
Changes made:

1) Add schemas to the final container to enable json validation
2) Copy the final binaries to /bin so that they can be run without having to supply the full path to the file.