### PR TITLE
Reduce memory consumption for verify

### DIFF
--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -138,14 +138,10 @@ func main() {
 				continue
 			}
 
-			var buf bytes.Buffer
-			buf.Write(header)
-			rw := io.ReadWriter(&buf)
-			if _, e := io.Copy(rw, f); e != nil {
-				log.Error(e)
-			}
+			hr := bytes.NewReader(header)
+			mr := io.MultiReader(hr, f)
 
-			c4ghr, err := streaming.NewCrypt4GHReader(rw, key, nil)
+			c4ghr, err := streaming.NewCrypt4GHReader(mr, key, nil)
 			if err != nil {
 				log.Error(err)
 				continue
@@ -155,6 +151,7 @@ func main() {
 			sha256hash := sha256.New()
 
 			stream := io.TeeReader(c4ghr, md5hash)
+
 			if _, err := io.Copy(sha256hash, stream); err != nil {
 				log.Error(err)
 				continue

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/aws/aws-sdk-go v1.34.7
-	github.com/elixir-oslo/crypt4gh v1.0.0
+	github.com/elixir-oslo/crypt4gh v1.0.1
 	github.com/google/uuid v1.1.1
 	github.com/lib/pq v1.8.0
 	github.com/sirupsen/logrus v1.6.0


### PR DESCRIPTION
Avoid reading data into memory to fead into Crypt4GHReader, use a special reader to
return a supplied header first and then return data read from a "proper" reader.