### PR TITLE
Allow some concurrency handling

### DIFF
--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -29,7 +29,6 @@ var testS3Conf = S3Conf{
 	"secretkey",
 	"bucket",
 	"region",
-	10,
 	5 * 1024 * 1024,
 	"../../dev_utils/certs/ca.pem"}
 


### PR DESCRIPTION
One way of addressing #117 (that i'm not thoroughly happy with, especially falling back on memory allocation when concurrency is requested may be unhelpful and may need a better solution. We may also need to redo the tests to test with larger (multi-part) objects.

Actually make it possible to configure s3 concurrency.

Rewritten S3 object fetcher so it uses a downloader to enable passing a
concurrency.

Fallout from the rewritten object fetcher is revamped handling to
provider the reader.