### PR TITLE
Allow some concurrency handling

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -175,6 +175,10 @@ func configS3Storage(prefix string) storage.S3Conf {
 		s3.Chunksize = viper.GetInt(prefix+".chunksize") * 1024 * 1024
 	}
 
+	if viper.IsSet(prefix + ".concurrent") {
+		s3.Concurrency = viper.GetInt(prefix + ".concurrent")
+	}
+
 	if viper.IsSet(prefix + ".cacert") {
 		s3.Cacert = viper.GetString(prefix + ".cacert")
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -162,6 +162,7 @@ func configS3Storage(prefix string) storage.S3Conf {
 
 	s3.Port = 443
 	s3.Region = "us-east-1"
+	s3.Concurrency = 1
 
 	if viper.IsSet(prefix + ".port") {
 		s3.Port = viper.GetInt(prefix + ".port")

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -161,7 +161,8 @@ func newS3Backend(config S3Conf) *s3Backend {
 		})}
 }
 
-// Helper writer to be used for downloader if concurrency is disabled
+// downloadWriterAt is a helper writer to be used for downloads. Uses a Cond to enable state
+// synchronization between gofuncs.
 type downloadWriterAt struct {
 	w        io.WriteCloser
 	written  int64
@@ -169,8 +170,7 @@ type downloadWriterAt struct {
 	cond     *sync.Cond
 }
 
-// Simple WriteAt that can only be used to channel through to a non-seekable Writer
-// could be expanded with a floating buffer if required
+// WriteAt function for downloadWriterAt to be used to channel through to a non-seekable Writer.
 func (dwa *downloadWriterAt) WriteAt(p []byte, offset int64) (n int, err error) {
 	// Ensure we have the lock
 	dwa.cond.L.Lock()

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -2,6 +2,7 @@
 package storage
 
 import (
+	"bytes"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -95,22 +97,23 @@ func (pb *posixBackend) GetFileSize(filePath string) (int64, error) {
 }
 
 type s3Backend struct {
-	Client   *s3.S3
-	Uploader *s3manager.Uploader
-	Bucket   string
+	Client     *s3.S3
+	Downloader *s3manager.Downloader
+	Uploader   *s3manager.Uploader
+	Bucket     string
 }
 
 // S3Conf stores information about the S3 storage backend
 type S3Conf struct {
-	URL               string
-	Port              int
-	AccessKey         string
-	SecretKey         string
-	Bucket            string
-	Region            string
-	UploadConcurrency int
-	Chunksize         int
-	Cacert            string
+	URL         string
+	Port        int
+	AccessKey   string
+	SecretKey   string
+	Bucket      string
+	Region      string
+	Concurrency int
+	Chunksize   int
+	Cacert      string
 }
 
 func newS3Backend(config S3Conf) *s3Backend {
@@ -143,29 +146,103 @@ func newS3Backend(config S3Conf) *s3Backend {
 		}
 	}
 
+	s3client := s3.New(s3Session)
+
 	return &s3Backend{
 		Bucket: config.Bucket,
 		Uploader: s3manager.NewUploader(s3Session, func(u *s3manager.Uploader) {
 			u.PartSize = int64(config.Chunksize)
-			u.Concurrency = config.UploadConcurrency
+			u.Concurrency = config.Concurrency
 			u.LeavePartsOnError = false
 		}),
-		Client: s3.New(s3Session)}
+		Client: s3client,
+		Downloader: s3manager.NewDownloaderWithClient(s3client, func(d *s3manager.Downloader) {
+			d.PartSize = int64(config.Chunksize)
+			d.Concurrency = config.Concurrency
+		})}
 }
 
-// NewFileReader returns an io.Reader instance
-func (sb *s3Backend) NewFileReader(filePath string) (io.ReadCloser, error) {
-	r, err := sb.Client.GetObject(&s3.GetObjectInput{
-		Bucket: aws.String(sb.Bucket),
-		Key:    aws.String(filePath),
-	})
+// Helper writer to be used for downloader if concurrency is disabled
+type downloadWriterAt struct {
+	w       io.Writer
+	written int64
+}
 
+// Simple WriteAt that can only be used to channel through to a non-seekable Writer
+// could be expanded with a floating buffer if required
+func (dwa downloadWriterAt) WriteAt(p []byte, offset int64) (n int, err error) {
+	if offset != dwa.written {
+		log.Errorf("Received write to unexpected offset for pipe")
+		return 0, fmt.Errorf("Can't do out-of-order writes to pipe, adjust concurrency")
+	}
+	return dwa.w.Write(p)
+}
+
+// Helper type to give a fake Close method
+type downloadReader struct {
+	r io.Reader
+}
+
+// Pass-through Read method for downloadReader
+func (dr downloadReader) Read(p []byte) (n int, err error) {
+	return dr.r.Read(p)
+}
+
+// Fake Closer, never fails
+func (dr downloadReader) Close() (err error) {
+	return nil
+}
+
+// NewFileReader returns an io.ReadCloser instance that's fed from the
+// object
+func (sb *s3Backend) NewFileReader(filePath string) (io.ReadCloser, error) {
+	fileSize, err := sb.GetFileSize(filePath)
+
+	// Bail out early if the object does not exist, adds one roundtrip
+	// but probably still worth it
 	if err != nil {
 		log.Error(err)
 		return nil, err
 	}
 
-	return r.Body, nil
+	var wg sync.WaitGroup
+	var reader io.ReadCloser
+	var writer io.WriterAt
+
+	wg.Add(1)
+
+	if sb.Downloader.Concurrency == 1 {
+		// No concurrency - use a pipe
+		var pipeWriter io.Writer
+		reader, pipeWriter = io.Pipe()
+		writer = downloadWriterAt{pipeWriter, 0}
+	} else {
+		// Concurrent download, download to memory buffer (unclear how
+		// useful this is)
+		buf := make([]byte, fileSize)
+		writer = aws.NewWriteAtBuffer(buf)
+		reader = downloadReader{bytes.NewReader(buf)}
+	}
+
+	go func() {
+		_, err := sb.Downloader.Download(writer, &s3.GetObjectInput{
+			Bucket: aws.String(sb.Bucket),
+			Key:    aws.String(filePath),
+		})
+
+		if err != nil {
+			log.Error(err)
+
+		}
+
+		wg.Done()
+	}()
+
+	if sb.Downloader.Concurrency != 1 {
+		// For memory downloads, wait until they are completed
+		wg.Wait()
+	}
+	return reader, nil
 }
 
 // NewFileWriter uploads the contents of an io.Reader to a S3 bucket

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -267,7 +267,7 @@ func TestDownloadWriterAtOutOfOrder(t *testing.T) {
 
 	// Assume this is enough fot things to happen rather than doing anoter
 	// waitgroup
-	time.Sleep(15000)
+	time.Sleep(1500000)
 
 	assert.Equal(t, 58, buf.Len(), "Not expected amount of bytes written")
 	assert.Equal(t, []byte("This goes first. This goes in the middle. This goes last. "),

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -43,7 +43,7 @@ var ts *httptest.Server
 var s3DoesNotExist = "nothing such"
 var s3Creatable = "somename"
 
-var writeData = []byte(strings.Repeat("this is a test", 575000))
+var writeData = []byte(strings.Repeat("this is a test, we want to use a not too small object to test some limits", 750000))
 
 var cleanupFilesBack [1000]string
 var cleanupFiles []string = cleanupFilesBack[0:0]
@@ -152,12 +152,12 @@ func TestPosixBackend(t *testing.T) {
 	var readBackBuffer [4096]byte
 	for offset := 0; offset < len(writeData); {
 
-			readBack, err := reader.Read(readBackBuffer[0:4096])
+		readBack, err := reader.Read(readBackBuffer[0:4096])
 
-			assert.Equal(t, writeData[offset:offset+readBack], readBackBuffer[:readBack], "did not read back data as expected")
-			assert.Nil(t, err, "unexpected error when reading back data")
+		assert.Equal(t, writeData[offset:offset+readBack], readBackBuffer[:readBack], "did not read back data as expected")
+		assert.Nil(t, err, "unexpected error when reading back data")
 
-			offset += readBack
+		offset += readBack
 	}
 
 	size, err := backend.GetFileSize(writable)


### PR DESCRIPTION
This is #118 as a zombie!

(This is intended to fix #117.)

While working on #127, I came up with this way that seems better. 

Actually make it possible to configure s3 concurrency.

Rewritten S3 object fetcher so it uses a downloader to enable passing a
concurrency.

To use the downloader with a pipe, we need an intermediate writer that supports the WriteAt interface. That writer keeps track of the amount of data it has written to not accept writes out of order.

To support concurrency, we use a lock to synchronize so access (both to the actual pipe and the current "offset" is available to just one thread at a time).