### PR TITLE
Bail out earlier on problems

### DIFF
--- a/cmd/ingest/ingest.go
+++ b/cmd/ingest/ingest.go
@@ -9,14 +9,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 
 	"sda-pipeline/internal/broker"
 	"sda-pipeline/internal/config"
 	"sda-pipeline/internal/database"
 	"sda-pipeline/internal/storage"
 
-	"github.com/elixir-oslo/crypt4gh/keys"
 	"github.com/elixir-oslo/crypt4gh/model/headers"
 	"github.com/elixir-oslo/crypt4gh/streaming"
 	"github.com/google/uuid"
@@ -61,7 +59,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	key, err := readKey(conf.Crypt4gh)
+	key, err := config.GetC4GHKey()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -268,23 +266,6 @@ func main() {
 	}()
 
 	<-forever
-}
-
-// readKey reads and decrypts the c4gh key so it's ready for use
-func readKey(conf config.Crypt4gh) (*[32]byte, error) {
-	// Make sure the key path and passphrase is valid
-	keyFile, err := os.Open(conf.KeyPath)
-	if err != nil {
-		return nil, err
-	}
-
-	key, err := keys.ReadPrivateKey(keyFile, []byte(conf.Passphrase))
-	if err != nil {
-		return nil, err
-	}
-
-	keyFile.Close()
-	return &key, nil
 }
 
 // tryDecrypt tries to decrypt the start of buf.

--- a/cmd/ingest/ingest.go
+++ b/cmd/ingest/ingest.go
@@ -61,6 +61,23 @@ func main() {
 		log.Fatal(err)
 	}
 
+	key, err := readKey(conf.Crypt4gh)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	archive, err := storage.NewBackend(conf.Archive)
+	if err != nil {
+		log.Fatal(err)
+
+	}
+
+	inbox, err := storage.NewBackend(conf.Inbox)
+	if err != nil {
+		log.Fatal(err)
+
+	}
+
 	defer mq.Channel.Close()
 	defer mq.Connection.Close()
 	defer db.Close()
@@ -89,9 +106,6 @@ func main() {
 				// publish MQ error
 				continue
 			}
-
-			archive := storage.NewBackend(conf.Archive)
-			inbox := storage.NewBackend(conf.Inbox)
 
 			log.Debugf("Received a message: %s", delivered.Body)
 			if err := json.Unmarshal(delivered.Body, &message); err != nil {
@@ -156,7 +170,7 @@ func main() {
 
 				//nolint:nestif
 				if bytesRead <= int64(len(readBuffer)) {
-					header, err := tryDecrypt(conf.Crypt4gh, readBuffer)
+					header, err := tryDecrypt(key, readBuffer)
 					if err != nil {
 						log.Errorln(err)
 						continue
@@ -256,21 +270,29 @@ func main() {
 	<-forever
 }
 
+// readKey reads and decrypts the c4gh key so it's ready for use
+func readKey(conf config.Crypt4gh) (*[32]byte, error) {
+	// Make sure the key path and passphrase is valid
+	keyFile, err := os.Open(conf.KeyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	key, err := keys.ReadPrivateKey(keyFile, []byte(conf.Passphrase))
+	if err != nil {
+		return nil, err
+	}
+
+	keyFile.Close()
+	return &key, nil
+}
+
 // tryDecrypt tries to decrypt the start of buf.
-func tryDecrypt(c config.Crypt4gh, buf []byte) ([]byte, error) {
-	keyFile, err := os.Open(c.KeyPath)
-	if err != nil {
-		log.Error(err)
-		return nil, err
-	}
-	key, err := keys.ReadPrivateKey(keyFile, []byte(c.Passphrase))
-	if err != nil {
-		log.Error(err)
-		return nil, err
-	}
+func tryDecrypt(key *[32]byte, buf []byte) ([]byte, error) {
+
 	log.Debugln("Try decrypting the first data block")
 	a := bytes.NewReader(buf)
-	b, err := streaming.NewCrypt4GHReader(a, key, nil)
+	b, err := streaming.NewCrypt4GHReader(a, *key, nil)
 	if err != nil {
 		log.Error(err)
 		return nil, err
@@ -281,7 +303,6 @@ func tryDecrypt(c config.Crypt4gh, buf []byte) ([]byte, error) {
 		log.Error(err)
 		return nil, err
 	}
-	keyFile.Close()
 
 	f := bytes.NewReader(buf)
 	header, err := headers.ReadHeader(f)

--- a/cmd/ingest/ingest_test.go
+++ b/cmd/ingest/ingest_test.go
@@ -39,31 +39,27 @@ func (suite *TestSuite) SetupTest() {
 	viper.Set("db.database", "test")
 }
 
-func (suite *TestSuite) TestTryDecrypt_keyError() {
+func (suite *TestSuite) TestReadKey_keyError() {
 
 	viper.Set("c4gh.filepath", "/tmp/foo")
 	config, err := config.NewConfig("verify")
 	assert.NotNil(suite.T(), config)
 	assert.NoError(suite.T(), err)
 
-	buf := make([]byte, 1024)
-
-	byte, err := tryDecrypt(config.Crypt4gh, buf)
+	byte, err := readKey(config.Crypt4gh)
 	assert.Nil(suite.T(), byte)
 	assert.EqualError(suite.T(), err, "open /tmp/foo: no such file or directory")
 }
 
-func (suite *TestSuite) TestTryDecrypt_passError() {
+func (suite *TestSuite) TestReadKey_passError() {
 
 	viper.Set("c4gh.passphrase", "asdf")
 	config, err := config.NewConfig("verify")
 	assert.NotNil(suite.T(), config)
 	assert.NoError(suite.T(), err)
 
-	buf := make([]byte, 1024)
-
-	byte, err := tryDecrypt(config.Crypt4gh, buf)
-	assert.Nil(suite.T(), byte)
+	key, err := readKey(config.Crypt4gh)
+	assert.Nil(suite.T(), key)
 	assert.EqualError(suite.T(), err, "chacha20poly1305: message authentication failed")
 }
 
@@ -79,7 +75,10 @@ func (suite *TestSuite) TestTryDecrypt_wrongFile() {
 	_, err = io.ReadFull(file, buf)
 	assert.NoError(suite.T(), err)
 
-	b, err := tryDecrypt(config.Crypt4gh, buf)
+	key, err := readKey(config.Crypt4gh)
+	assert.Nil(suite.T(), err)
+
+	b, err := tryDecrypt(key, buf)
 	assert.Nil(suite.T(), b)
 	assert.EqualError(suite.T(), err, "not a Crypt4GH file")
 }
@@ -97,8 +96,12 @@ func (suite *TestSuite) TestTryDecrypt() {
 	_, err = io.ReadFull(file, buf)
 	assert.NoError(suite.T(), err)
 
+	key, err := readKey(config.Crypt4gh)
+	assert.Nil(suite.T(), err)
+
 	data := []byte{99, 114, 121, 112, 116, 52, 103, 104, 1, 0, 0, 0, 1, 0, 0, 0, 108, 0, 0, 0, 0, 0, 0, 0, 106, 241, 64, 122, 188, 116, 101, 107, 137, 19, 167, 211, 35, 196, 191, 211, 11, 247, 200, 202, 53, 159, 116, 174, 53, 53, 122, 206, 242, 157, 197, 7, 55, 153, 226, 7, 236, 93, 2, 43, 38, 1, 52, 5, 133, 255, 8, 37, 101, 229, 95, 191, 245, 182, 205, 187, 190, 107, 18, 160, 208, 161, 158, 243, 37, 162, 25, 248, 182, 35, 68, 50, 94, 34, 200, 210, 106, 142, 130, 228, 95, 5, 63, 77, 206, 225, 12, 14, 196, 187, 158, 70, 109, 82, 83, 241, 57, 220, 212, 190}
-	b, err := tryDecrypt(config.Crypt4gh, buf)
+
+	b, err := tryDecrypt(key, buf)
 	assert.Equal(suite.T(), b, data)
 	assert.NoError(suite.T(), err)
 }

--- a/cmd/ingest/ingest_test.go
+++ b/cmd/ingest/ingest_test.go
@@ -39,34 +39,7 @@ func (suite *TestSuite) SetupTest() {
 	viper.Set("db.database", "test")
 }
 
-func (suite *TestSuite) TestReadKey_keyError() {
-
-	viper.Set("c4gh.filepath", "/tmp/foo")
-	config, err := config.NewConfig("verify")
-	assert.NotNil(suite.T(), config)
-	assert.NoError(suite.T(), err)
-
-	byte, err := readKey(config.Crypt4gh)
-	assert.Nil(suite.T(), byte)
-	assert.EqualError(suite.T(), err, "open /tmp/foo: no such file or directory")
-}
-
-func (suite *TestSuite) TestReadKey_passError() {
-
-	viper.Set("c4gh.passphrase", "asdf")
-	config, err := config.NewConfig("verify")
-	assert.NotNil(suite.T(), config)
-	assert.NoError(suite.T(), err)
-
-	key, err := readKey(config.Crypt4gh)
-	assert.Nil(suite.T(), key)
-	assert.EqualError(suite.T(), err, "chacha20poly1305: message authentication failed")
-}
-
 func (suite *TestSuite) TestTryDecrypt_wrongFile() {
-	config, err := config.NewConfig("verify")
-	assert.NotNil(suite.T(), config)
-	assert.NoError(suite.T(), err)
 
 	buf := make([]byte, 1024)
 	file, err := os.Open("../../dev_utils/README.md")
@@ -75,7 +48,7 @@ func (suite *TestSuite) TestTryDecrypt_wrongFile() {
 	_, err = io.ReadFull(file, buf)
 	assert.NoError(suite.T(), err)
 
-	key, err := readKey(config.Crypt4gh)
+	key, err := config.GetC4GHKey()
 	assert.Nil(suite.T(), err)
 
 	b, err := tryDecrypt(key, buf)
@@ -84,9 +57,6 @@ func (suite *TestSuite) TestTryDecrypt_wrongFile() {
 }
 
 func (suite *TestSuite) TestTryDecrypt() {
-	config, err := config.NewConfig("verify")
-	assert.NotNil(suite.T(), config)
-	assert.NoError(suite.T(), err)
 
 	buf := make([]byte, 65*1024)
 
@@ -96,7 +66,7 @@ func (suite *TestSuite) TestTryDecrypt() {
 	_, err = io.ReadFull(file, buf)
 	assert.NoError(suite.T(), err)
 
-	key, err := readKey(config.Crypt4gh)
+	key, err := config.GetC4GHKey()
 	assert.Nil(suite.T(), err)
 
 	data := []byte{99, 114, 121, 112, 116, 52, 103, 104, 1, 0, 0, 0, 1, 0, 0, 0, 108, 0, 0, 0, 0, 0, 0, 0, 106, 241, 64, 122, 188, 116, 101, 107, 137, 19, 167, 211, 35, 196, 191, 211, 11, 247, 200, 202, 53, 159, 116, 174, 53, 53, 122, 206, 242, 157, 197, 7, 55, 153, 226, 7, 236, 93, 2, 43, 38, 1, 52, 5, 133, 255, 8, 37, 101, 229, 95, 191, 245, 182, 205, 187, 190, 107, 18, 160, 208, 161, 158, 243, 37, 162, 25, 248, 182, 35, 68, 50, 94, 34, 200, 210, 106, 142, 130, 228, 95, 5, 63, 77, 206, 225, 12, 14, 196, 187, 158, 70, 109, 82, 83, 241, 57, 220, 212, 190}

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -65,7 +65,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	key, err := readKey(conf.Crypt4gh)
+	key, err := config.GetC4GHKey()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -212,21 +212,4 @@ func main() {
 	}()
 
 	<-forever
-}
-
-// readKey reads and decrypts the c4gh key so it's ready for use
-func readKey(conf config.Crypt4gh) (*[32]byte, error) {
-	// Make sure the key path and passphrase is valid
-	keyFile, err := os.Open(conf.KeyPath)
-	if err != nil {
-		return nil, err
-	}
-
-	key, err := keys.ReadPrivateKey(keyFile, []byte(conf.Passphrase))
-	if err != nil {
-		return nil, err
-	}
-
-	keyFile.Close()
-	return &key, nil
 }

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -9,14 +9,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 
 	"sda-pipeline/internal/broker"
 	"sda-pipeline/internal/config"
 	"sda-pipeline/internal/database"
 	"sda-pipeline/internal/storage"
 
-	"github.com/elixir-oslo/crypt4gh/keys"
 	"github.com/elixir-oslo/crypt4gh/streaming"
 	"github.com/xeipuuv/gojsonschema"
 
@@ -127,18 +125,6 @@ func main() {
 				}
 				continue
 			}
-
-			// do file verfication
-			keyFile, err := os.Open(conf.Crypt4gh.KeyPath)
-			if err != nil {
-				log.Error(err)
-			}
-
-			key, err := keys.ReadPrivateKey(keyFile, []byte(conf.Crypt4gh.Passphrase))
-			if err != nil {
-				log.Error(err)
-			}
-			keyFile.Close()
 
 			f, err := backend.NewFileReader(message.ArchivePath)
 			if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -349,9 +349,6 @@ func (suite *TestSuite) TestVerifyConfiguration() {
 	assert.NotNil(suite.T(), config.Archive)
 	assert.NotNil(suite.T(), config.Archive.Posix)
 	assert.Equal(suite.T(), "test", config.Archive.Posix.Location)
-	assert.NotNil(suite.T(), config.Crypt4gh)
-	assert.Equal(suite.T(), "test", config.Crypt4gh.KeyPath)
-	assert.Equal(suite.T(), "test", config.Crypt4gh.Passphrase)
 
 	// Clear variables
 	viper.Reset()
@@ -408,9 +405,6 @@ func (suite *TestSuite) TestIngestConfiguration() {
 	assert.NotNil(suite.T(), config.Archive)
 	assert.NotNil(suite.T(), config.Archive.Posix)
 	assert.Equal(suite.T(), "test", config.Archive.Posix.Location)
-	assert.NotNil(suite.T(), config.Crypt4gh)
-	assert.Equal(suite.T(), "test", config.Crypt4gh.KeyPath)
-	assert.Equal(suite.T(), "test", config.Crypt4gh.Passphrase)
 
 	// Clear variables
 	viper.Reset()
@@ -487,4 +481,23 @@ func (suite *TestSuite) TestConfigPath() {
 	assert.Error(suite.T(), err)
 	absPath, _ := filepath.Abs("../../dev_utils/config.yaml")
 	assert.Equal(suite.T(), absPath, viper.ConfigFileUsed())
+}
+
+func (suite *TestSuite) TestGetC4GHKey_keyError() {
+
+	viper.Set("c4gh.filepath", "/doesnotexist")
+
+	byte, err := GetC4GHKey()
+	assert.Nil(suite.T(), byte)
+	assert.EqualError(suite.T(), err, "open /doesnotexist: no such file or directory")
+}
+
+func (suite *TestSuite) TestGetC4GHKey_passError() {
+
+	viper.Set("c4gh.filepath", "../../dev_utils/c4gh.sec.pem")
+	viper.Set("c4gh.passphrase", "asdf")
+
+	key, err := GetC4GHKey()
+	assert.Nil(suite.T(), key)
+	assert.EqualError(suite.T(), err, "chacha20poly1305: message authentication failed")
 }


### PR DESCRIPTION
Moved some things that can be reused so they are initialized before the main loop. Also, verify storage backends upon creation.

Fixes #110, #111 and #112.


This currently uses ListObjectsV2 from s3 and requires that not to fail. That adds a requirement for s3 backends to have read permissions to the bucket. I believe that is acceptable (but worth mentioning especially).