### PR TITLE
mapper does not require broker.routingkey

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,17 +21,7 @@ import (
 const POSIX = "posix"
 const S3 = "s3"
 
-var (
-	// requiredConfVars determines what needs to be provided as a minimum
-	requiredConfVars = []string{
-		"broker.host", "broker.port", "broker.user", "broker.password", "broker.queue",
-	}
-
-	// requiredConfVarsExtra contains more variables required for most services
-	requiredConfVarsExtra = []string{
-		"broker.routingkey", "db.host", "db.port", "db.user", "db.password", "db.database",
-	}
-)
+var requiredConfVars []string
 
 // Config is a parent object for all the different configuration parts
 type Config struct {
@@ -68,6 +58,23 @@ func NewConfig(app string) (*Config, error) {
 		}
 	}
 
+	switch app {
+	case "intercept":
+		// Intercept does not require these extra settings
+		requiredConfVars = []string{
+			"broker.host", "broker.port", "broker.user", "broker.password", "broker.queue",
+		}
+	case "mapper":
+		// Mapper does not require broker.routingkey thus we remove it
+		requiredConfVars = []string{
+			"broker.host", "broker.port", "broker.user", "broker.password", "broker.queue", "db.host", "db.port", "db.user", "db.password", "db.database",
+		}
+	default:
+		requiredConfVars = []string{
+			"broker.host", "broker.port", "broker.user", "broker.password", "broker.queue", "broker.routingkey", "db.host", "db.port", "db.user", "db.password", "db.database",
+		}
+	}
+
 	if viper.GetString("archive.type") == S3 {
 		requiredConfVars = append(requiredConfVars, []string{"archive.url", "archive.accesskey", "archive.secretkey", "archive.bucket"}...)
 	} else if viper.GetString("archive.type") == POSIX {
@@ -78,17 +85,6 @@ func NewConfig(app string) (*Config, error) {
 		requiredConfVars = append(requiredConfVars, []string{"inbox.url", "inbox.accesskey", "inbox.secretkey", "inbox.bucket"}...)
 	} else if viper.GetString("inbox.type") == POSIX {
 		requiredConfVars = append(requiredConfVars, []string{"inbox.location"}...)
-	}
-
-	if app != "intercept" {
-		// Intercept does not require these extra settings
-		requiredConfVars = append(requiredConfVars, requiredConfVarsExtra...)
-	}
-
-	if app == "mapper" {
-		// Mapper does not require broker.routingkey thus we remove it
-		// if new vars are added this will need to be redone
-		requiredConfVars = append(requiredConfVars[:5], requiredConfVars[6:]...)
 	}
 
 	for _, s := range requiredConfVars {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,6 +85,12 @@ func NewConfig(app string) (*Config, error) {
 		requiredConfVars = append(requiredConfVars, requiredConfVarsExtra...)
 	}
 
+	if app == "mapper" {
+		// Mapper does not require broker.routingkey thus we remove it
+		// if new vars are added this will need to be redone
+		requiredConfVars = append(requiredConfVars[:5], requiredConfVars[6:]...)
+	}
+
 	for _, s := range requiredConfVars {
 		if !viper.IsSet(s) {
 			return nil, fmt.Errorf("%s not set", s)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -244,7 +244,6 @@ func (suite *TestSuite) TestMapperConfiguration() {
 	assert.Equal(suite.T(), "test", config.Broker.User)
 	assert.Equal(suite.T(), "test", config.Broker.Password)
 	assert.Equal(suite.T(), "test", config.Broker.Queue)
-	assert.Equal(suite.T(), "test", config.Broker.RoutingKey)
 	assert.NotNil(suite.T(), config.Database)
 	assert.Equal(suite.T(), "test", config.Database.Host)
 	assert.Equal(suite.T(), 123, config.Database.Port)


### PR DESCRIPTION
we re-slice the requiredConfVars just for mapper removing the broker.routingkey

As pointed at: https://github.com/neicnordic/sda-helm/pull/47