### PR TITLE
Store decrypted file size (and other attributes).

### DIFF
--- a/.github/integration/setup/common/10_services.sh
+++ b/.github/integration/setup/common/10_services.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Build containers
-docker build -t neicnordic/sda-pipeline:latest .
+docker build -t neicnordic/sda-pipeline:latest . || exit 1
 
 
 cd dev_utils || exit 1

--- a/.github/integration/tests/common/30_ingest_test.sh
+++ b/.github/integration/tests/common/30_ingest_test.sh
@@ -266,7 +266,7 @@ done
 
 docker run --rm --name client --network dev_utils_default \
 neicnordic/pg-client:latest postgresql://lega_out:lega_out@db:5432/lega \
--t -c "SELECT * from local_ega_ebi.file_dataset ORDER BY id DESC"
+-t -c "SELECT * from local_ega_ebi.file_dataset"
 
 docker run --rm --name client --network dev_utils_default \
 neicnordic/pg-client:latest postgresql://lega_out:lega_out@db:5432/lega \

--- a/.github/integration/tests/common/30_ingest_test.sh
+++ b/.github/integration/tests/common/30_ingest_test.sh
@@ -2,7 +2,7 @@
 
 docker run --rm --name client --network dev_utils_default \
 neicnordic/pg-client:latest postgresql://lega_out:lega_out@db:5432/lega \
--t -c "SELECT * from local_ega_ebi.file_dataset ORDER BY id DESC"
+-t -c "SELECT * from local_ega_ebi.file_dataset"
 
 docker run --rm --name client --network dev_utils_default \
 neicnordic/pg-client:latest postgresql://lega_out:lega_out@db:5432/lega \

--- a/.github/integration/tests/common/30_ingest_test.sh
+++ b/.github/integration/tests/common/30_ingest_test.sh
@@ -31,9 +31,14 @@ for file in dummy_data.c4gh largefile.c4gh; do
     C4GH_PASSPHRASE=$(grep -F passphrase config.yaml | sed -e 's/.* //' -e 's/"//g')
     export C4GH_PASSPHRASE
 
-    decsha256sum=$(crypt4gh decrypt --sk c4gh.sec.pem < "$file" | sha256sum | cut -d' ' -f 1)
+    dcf=$(tempfile)
+
+    decsha256sum=$(crypt4gh decrypt --sk c4gh.sec.pem < "$file" | LANG=C dd bs=4M 2>"$dcf" | sha256sum | cut -d' ' -f 1)
     decmd5sum=$(crypt4gh decrypt --sk c4gh.sec.pem < "$file" | md5sum | cut -d' ' -f 1)
     
+    decryptedfilesize=$(sed -ne 's/^\([0-9][0-9]*\) bytes (.*) copied, .*$/\1/p' "$dcf")
+    rm -f "$dcf"
+
     curl -vvv -u test:test 'localhost:15672/api/exchanges/test/sda/publish' \
           -H 'Content-Type: application/json;charset=UTF-8' \
           --data-binary "$( echo '{
@@ -260,6 +265,32 @@ for file in dummy_data.c4gh largefile.c4gh; do
 	   fi
        fi
    done
+
+   decryptedsizedb=$(docker run --rm --name client --network dev_utils_default \
+		      neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
+		      -t -c "SELECT decrypted_file_size from local_ega.files where stable_id='$access';")
+
+   if [ "$decryptedsizedb" -eq "$decryptedfilesize" ]; then
+      # Use this logic to handle case of bad output from db (missing)
+      :
+   else
+      echo "File passed through flow but decrypted size in DB did not match real decrypted size."
+      # Temporarily disable failure here until accession issue is fixed
+      #exit 1
+   fi
+
+   decryptedchecksum=$(docker run --rm --name client --network dev_utils_default \
+		      neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
+		      -t -c "SELECT decrypted_file_checksum from local_ega.files where stable_id='$access';")
+
+   if [ "$decryptedchecksum" -eq "$decsha256sum" ]; then
+      # Use this logic to handle case of bad output from db (missing)
+      :
+     else
+      echo "File passed through flow but decrypted checksum in DB did not match real decrypted checksum."
+      # Temporarily disable failure here until accession issue is fixed
+      #exit 1
+   fi
 
     count=$((count+1))
 done

--- a/.github/integration/tests/common/30_ingest_test.sh
+++ b/.github/integration/tests/common/30_ingest_test.sh
@@ -110,10 +110,8 @@ for file in dummy_data.c4gh largefile.c4gh; do
     done
 
     now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-    access=$(printf "EGAF%011d" "$count" )
+    access=$(printf "EGAF%05d%06d" "$RANDOM" "$count" )
     
-
-
     archivepath=$(curl -u test:test 'localhost:15672/api/queues/test/verified/get' \
                 -H 'Content-Type: application/json;charset=UTF-8' \
                 -d '{"count":1,"ackmode":"ack_requeue_false","encoding":"auto","truncate":50000}' | \

--- a/.github/integration/tests/common/30_ingest_test.sh
+++ b/.github/integration/tests/common/30_ingest_test.sh
@@ -283,7 +283,7 @@ for file in dummy_data.c4gh largefile.c4gh; do
 		      neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
 		      -t -c "SELECT decrypted_file_checksum from local_ega.files where stable_id='$access';")
 
-   if [ "$decryptedchecksum" -eq "$decsha256sum" ]; then
+   if [ "$decryptedchecksum" = "$decsha256sum" ]; then
       # Use this logic to handle case of bad output from db (missing)
       :
      else

--- a/.github/integration/tests/common/30_ingest_test.sh
+++ b/.github/integration/tests/common/30_ingest_test.sh
@@ -283,7 +283,7 @@ for file in dummy_data.c4gh largefile.c4gh; do
 		      neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
 		      -t -c "SELECT decrypted_file_checksum from local_ega.files where stable_id='$access';")
 
-   if [ "$decryptedchecksum" = "$decsha256sum" ]; then
+   if [ "$(echo $decryptedchecksum)" = "$decsha256sum" ]; then
       # Use this logic to handle case of bad output from db (missing)
       :
      else

--- a/.github/integration/tests/common/30_ingest_test.sh
+++ b/.github/integration/tests/common/30_ingest_test.sh
@@ -273,8 +273,7 @@ for file in dummy_data.c4gh largefile.c4gh; do
       :
    else
       echo "File passed through flow but decrypted size in DB did not match real decrypted size."
-      # Temporarily disable failure here until accession issue is fixed
-      #exit 1
+      exit 1
    fi
 
    decryptedchecksum=$(docker run --rm --name client --network dev_utils_default \
@@ -286,8 +285,7 @@ for file in dummy_data.c4gh largefile.c4gh; do
       :
      else
       echo "File passed through flow but decrypted checksum in DB did not match real decrypted checksum."
-      # Temporarily disable failure here until accession issue is fixed
-      #exit 1
+      exit 1
    fi
 
     count=$((count+1))

--- a/.github/integration/tests/common/30_ingest_test.sh
+++ b/.github/integration/tests/common/30_ingest_test.sh
@@ -268,7 +268,7 @@ for file in dummy_data.c4gh largefile.c4gh; do
 
    decryptedsizedb=$(docker run --rm --name client --network dev_utils_default \
 		      neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
-		      -t -c "SELECT decrypted_file_size from local_ega.files where stable_id='$access';")
+		      -t -A -c "SELECT decrypted_file_size from local_ega.files where stable_id='$access';")
 
    if [ "$decryptedsizedb" -eq "$decryptedfilesize" ]; then
       # Use this logic to handle case of bad output from db (missing)
@@ -281,9 +281,9 @@ for file in dummy_data.c4gh largefile.c4gh; do
 
    decryptedchecksum=$(docker run --rm --name client --network dev_utils_default \
 		      neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
-		      -t -c "SELECT decrypted_file_checksum from local_ega.files where stable_id='$access';")
+		      -t -A -c "SELECT decrypted_file_checksum from local_ega.files where stable_id='$access';")
 
-   if [ "$(echo $decryptedchecksum)" = "$decsha256sum" ]; then
+   if [ "$decryptedchecksum" = "$decsha256sum" ]; then
       # Use this logic to handle case of bad output from db (missing)
       :
      else

--- a/cmd/ingest/ingest.go
+++ b/cmd/ingest/ingest.go
@@ -221,7 +221,7 @@ func main() {
 				continue
 			}
 
-			fileInfo.Checksum = fmt.Sprintf("%x", hash.Sum(nil))
+			fileInfo.Checksum = hash
 			if err := db.SetArchived(fileInfo, fileID); err != nil {
 				log.Error("SetArchived failed")
 				// This should really be handled by the DB retry mechanism

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -171,7 +171,7 @@ func main() {
 				log.Debug("will run markcompleted")
 				// Mark file as "COMPLETED"
 				if e := db.MarkCompleted(file, message.FileID); e != nil {
-					log.Error("MarkCompleted failed: %v", e)
+					log.Errorf("MarkCompleted failed: %v", e)
 					continue
 					// this should really be hadled by the DB retry mechanism
 				} else {

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -168,11 +168,14 @@ func main() {
 
 			//nolint:nestif
 			if message.ReVerify == nil || !*message.ReVerify {
-				log.Debug("Mark completed")
+				log.Debug("will run markcompleted")
 				// Mark file as "COMPLETED"
 				if e := db.MarkCompleted(file, message.FileID); e != nil {
+					log.Error("MarkCompleted failed: %v", e)
+					continue
 					// this should really be hadled by the DB retry mechanism
 				} else {
+					log.Debug("Mark completed")
 					// Send message to verified
 					c := Verified{
 						User:     message.User,

--- a/dev_utils/compose-backend.yml
+++ b/dev_utils/compose-backend.yml
@@ -6,6 +6,10 @@ services:
     environment:
       - DB_LEGA_IN_PASSWORD=lega_in
       - DB_LEGA_OUT_PASSWORD=lega_out
+      - PKI_VOLUME_PATH=/certs/
+      - PG_CA=/var/lib/postgresql/tls/ca.pem
+      - PG_SERVER_CERT=/var/lib/postgresql/tls/db.pem
+      - PG_SERVER_KEY=/var/lib/postgresql/tls/db-key.pem
     healthcheck:
       test: ["CMD", "pg_isready", "-h", "localhost", "-U", "lega_out"]
       interval: 5s
@@ -16,6 +20,7 @@ services:
       - "5432:5432"
     volumes:
       - /tmp/data:/data
+      - ./certs:/certs
   mq:
     container_name: mq
     image: neicnordic/sda-mq:latest

--- a/dev_utils/compose-backend.yml
+++ b/dev_utils/compose-backend.yml
@@ -11,7 +11,7 @@ services:
       interval: 5s
       timeout: 20s
       retries: 3
-    image: neicnordic/sda-db:pipeline
+    image: neicnordic/sda-db:latest
     ports:
       - "5432:5432"
     volumes:

--- a/dev_utils/compose-sda.yml
+++ b/dev_utils/compose-sda.yml
@@ -1,52 +1,76 @@
 version: "2.4"
 services:
+  certfixer:
+    command: sh -c "cp /origcerts/* /certs && chown -R nobody.nobody /certs/ && chmod -R og-rw /certs/"
+    container_name: certfixer
+    image: alpine:latest
+    volumes:
+      - ./certs:/origcerts
+      - certs:/certs
   ingest:
     command: sda-ingest
     container_name: ingest
+    depends_on: 
+      - certfixer
     env_file: ./env.ingest
     image: neicnordic/sda-pipeline:latest
     volumes:
       - ./config.yaml:/config.yaml
       - ./:/dev_utils/
       - archive:/tmp
+      - certs:/dev_utils/certs
     mem_limit: 1024m
   verify:
     command: sda-verify
     container_name: verify
+    depends_on: 
+      - certfixer
     env_file: ./env.verify
     image: neicnordic/sda-pipeline:latest
     volumes:
       - ./config.yaml:/config.yaml
       - ./:/dev_utils/
       - archive:/tmp
+      - certs:/dev_utils/certs
 #    mem_limit: 256m
   finalize:
     command: sda-finalize
     container_name: finalize
+    depends_on: 
+      - certfixer
     env_file: ./env.finalize
     image: neicnordic/sda-pipeline:latest
     volumes:
       - ./config.yaml:/config.yaml
       - ./:/dev_utils/
+      - certs:/dev_utils/certs
     mem_limit: 64m
   mapper:
     command: sda-mapper
     container_name: mapper
+    depends_on: 
+      - certfixer
     env_file: ./env.mapper
     image: neicnordic/sda-pipeline:latest
     volumes:
       - ./config.yaml:/config.yaml
       - ./:/dev_utils/
+      - certs:/dev_utils/certs
     mem_limit: 64m
   interceptor:
     command: sda-intercept
     container_name: intercept
+    depends_on: 
+      - certfixer
     env_file: ./env.intercept
     image: neicnordic/sda-pipeline:latest
+    
     volumes:
       - ./config.yaml:/config.yaml
       - ./:/dev_utils/
+      - certs:/dev_utils/certs
     mem_limit: 64m
 
 volumes:
      archive:
+     certs:

--- a/dev_utils/compose-sda.yml
+++ b/dev_utils/compose-sda.yml
@@ -31,6 +31,7 @@ services:
     volumes:
       - ./config.yaml:/config.yaml
       - ./:/dev_utils/
+      - certs:/dev_utils/certs
       - archive:/tmp
     mem_limit: 256m
     restart: always

--- a/dev_utils/config.yaml
+++ b/dev_utils/config.yaml
@@ -43,7 +43,7 @@ db:
   cacert: "./dev_utils/certs/ca.pem"
   clientCert: "./dev_utils/certs/client.pem"
   clientKey: "./dev_utils/certs/client-key.pem"
-  sslmode: "disable"
+  sslmode: "verify-ca"
 
 inbox:
   type: ""

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -124,7 +124,7 @@ func (dbs *SQLdb) GetHeader(fileID int) ([]byte, error) {
 func (dbs *SQLdb) MarkCompleted(file FileInfo, fileID int) error {
 	db := dbs.DB
 	const completed = "UPDATE local_ega.files SET status = 'COMPLETED', " +
-		"archive_file_size = $2, " +
+		"archive_filesize = $2, " +
 		"archive_file_checksum = $3, " +
 		"archive_file_checksum_type = $4, " +
 		"decrypted_file_size = $5, " +

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -201,7 +201,8 @@ func (dbs *SQLdb) SetArchived(file FileInfo, id int64) error {
 // MarkReady marks the file as "READY"
 func (dbs *SQLdb) MarkReady(accessionID, user, filepath, checksum string) error {
 	db := dbs.DB
-	const ready = "UPDATE local_ega.files SET status = 'READY', stable_id = $1 WHERE elixir_id = $2 and archive_path = $3 and archive_file_checksum = $4 and status != 'DISABLED';"
+	const ready = "UPDATE local_ega.files SET status = 'READY', stable_id = $1 WHERE " +
+		"elixir_id = $2 and archive_path = $3 and decrypted_file_checksum = $4 and status != 'DISABLED';"
 	result, err := db.Exec(ready, accessionID, user, filepath, checksum)
 	if err != nil {
 		return err

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"hash"
 	"path/filepath"
 	"strings"
 
@@ -44,13 +45,21 @@ type DBConf struct {
 
 // FileInfo is used by ingest for file metadata (path, size, checksum)
 type FileInfo struct {
-	Checksum string
-	Size     int64
-	Path     string
+	Checksum          hash.Hash
+	Size              int64
+	Path              string
+	DecryptedChecksum hash.Hash
+	DecryptedSize     int64
 }
 
 // Internal variable to ease testing
 var sqlOpen = sql.Open
+
+// hashType returns the identification string for the hash type
+func hashType(h hash.Hash) string {
+	// TODO: Support/check type
+	return "SHA256"
+}
 
 // NewDB creates a new DB connection
 func NewDB(config DBConf) (*SQLdb, error) {
@@ -112,10 +121,24 @@ func (dbs *SQLdb) GetHeader(fileID int) ([]byte, error) {
 }
 
 // MarkCompleted marks the file as "COMPLETED"
-func (dbs *SQLdb) MarkCompleted(checksum string, fileID int) error {
+func (dbs *SQLdb) MarkCompleted(file FileInfo, fileID int) error {
 	db := dbs.DB
-	const completed = "UPDATE local_ega.files SET status = 'COMPLETED', archive_file_checksum = $1, archive_file_checksum_type = 'SHA256'  WHERE id = $2;"
-	result, err := db.Exec(completed, checksum, fileID)
+	const completed = "UPDATE local_ega.files SET status = 'COMPLETED', " +
+		"archive_file_size = $2, " +
+		"archive_file_checksum = $3, " +
+		"archive_file_checksum_type = $4, " +
+		"decrypted_file_size = $5, " +
+		"decrypted_file_checksum = $6, " +
+		"decrypted_file_checksum_type = $7 " +
+		"WHERE id = $1;"
+	result, err := db.Exec(completed,
+		fileID,
+		file.Size,
+		fmt.Sprintf("%x", file.Checksum.Sum(nil)),
+		hashType(file.Checksum),
+		file.DecryptedSize,
+		fmt.Sprintf("%x", file.DecryptedChecksum.Sum(nil)),
+		hashType(file.DecryptedChecksum))
 	if err != nil {
 		return err
 	}
@@ -154,8 +177,18 @@ func (dbs *SQLdb) StoreHeader(header []byte, id int64) error {
 // SetArchived marks the file as 'ARCHIVED'
 func (dbs *SQLdb) SetArchived(file FileInfo, id int64) error {
 	db := dbs.DB
-	const query = "UPDATE local_ega.files SET status = 'ARCHIVED', archive_path = $1, archive_filesize = $2, inbox_file_checksum = $3, inbox_file_checksum_type = 'SHA256' WHERE id = $4;"
-	result, err := db.Exec(query, file.Path, file.Size, file.Checksum, id)
+	const query = "UPDATE local_ega.files SET status = 'ARCHIVED', " +
+		"archive_path = $1, " +
+		"archive_filesize = $2, " +
+		"inbox_file_checksum = $3, " +
+		"inbox_file_checksum_type = $4 " +
+		"WHERE id = $5;"
+	result, err := db.Exec(query,
+		file.Path,
+		file.Size,
+		fmt.Sprintf("%x", file.Checksum.Sum(nil)),
+		hashType(file.Checksum),
+		id)
 	if err != nil {
 		return err
 	}

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -147,12 +148,32 @@ func sqlTesterHelper(t *testing.T, f func(sqlmock.Sqlmock, *SQLdb) error) error 
 }
 
 func TestMarkCompleted(t *testing.T) {
+	file := FileInfo{sha256.New(), 46, "/somepath", sha256.New(), 48}
+
+	file.Checksum.Write([]byte("checksum"))
+	file.DecryptedChecksum.Write([]byte("decryptedchecksum"))
+
 	r := sqlTesterHelper(t, func(mock sqlmock.Sqlmock, testDb *SQLdb) error {
+
 		r := sqlmock.NewResult(10, 1)
 
-		mock.ExpectExec("UPDATE local_ega.files SET status = 'COMPLETED', archive_file_checksum = \\$1, archive_file_checksum_type = 'SHA256'  WHERE id = \\$2").WithArgs("1", 10).WillReturnResult(r)
+		mock.ExpectExec("UPDATE local_ega.files SET status = 'COMPLETED', "+
+			"archive_file_size = \\$2, "+
+			"archive_file_checksum = \\$3, "+
+			"archive_file_checksum_type = \\$4, "+
+			"decrypted_file_size = \\$5, "+
+			"decrypted_file_checksum = \\$6, "+
+			"decrypted_file_checksum_type = \\$7 "+
+			"WHERE id = \\$1;").WithArgs(
+			10,
+			file.Size,
+			"96fa8f226d3801741e807533552bc4b177ac4544d834073b6a5298934d34b40b",
+			"SHA256",
+			file.DecryptedSize,
+			"b353d3058b350466bb75a4e5e2263c73a7b900e2c48804780c6dd820b8b151ba",
+			"SHA256").WillReturnResult(r)
 
-		return testDb.MarkCompleted("1", 10)
+		return testDb.MarkCompleted(file, 10)
 	})
 
 	assert.Nil(t, r, "MarkCompleted failed unexpectedly")
@@ -162,11 +183,25 @@ func TestMarkCompleted(t *testing.T) {
 
 	buf.Reset()
 	r = sqlTesterHelper(t, func(mock sqlmock.Sqlmock, testDb *SQLdb) error {
-		mock.ExpectExec("UPDATE local_ega.files SET status = 'COMPLETED', archive_file_checksum = \\$1, archive_file_checksum_type = 'SHA256'  WHERE id = \\$2").
-			WithArgs("1", 10).
+
+		mock.ExpectExec("UPDATE local_ega.files SET status = 'COMPLETED', "+
+			"archive_file_size = \\$2, "+
+			"archive_file_checksum = \\$3, "+
+			"archive_file_checksum_type = \\$4, "+
+			"decrypted_file_size = \\$5, "+
+			"decrypted_file_checksum = \\$6, "+
+			"decrypted_file_checksum_type = \\$7 "+
+			"WHERE id = \\$1;").
+			WithArgs(10,
+				file.Size,
+				"96fa8f226d3801741e807533552bc4b177ac4544d834073b6a5298934d34b40b",
+				"SHA256",
+				file.DecryptedSize,
+				"b353d3058b350466bb75a4e5e2263c73a7b900e2c48804780c6dd820b8b151ba",
+				"SHA256").
 			WillReturnError(fmt.Errorf("error for testing"))
 
-		return testDb.MarkCompleted("1", 10)
+		return testDb.MarkCompleted(file, 10)
 	})
 
 	assert.NotNil(t, r, "MarkCompleted did not fail as expected")
@@ -244,13 +279,19 @@ func TestStoreHeader(t *testing.T) {
 
 func TestSetArchived(t *testing.T) {
 
+	file := FileInfo{sha256.New(), 1000, "/tmp/file.c4gh", sha256.New(), -1}
+	file.Checksum.Write([]byte("checksum"))
+
 	r := sqlTesterHelper(t, func(mock sqlmock.Sqlmock, testDb *SQLdb) error {
 
-		file := FileInfo{"10", 1000, "/tmp/file.c4gh"}
 		r := sqlmock.NewResult(10, 1)
 
-		mock.ExpectExec("UPDATE local_ega.files SET status = 'ARCHIVED', archive_path = \\$1, archive_filesize = \\$2, inbox_file_checksum = \\$3, inbox_file_checksum_type = 'SHA256' WHERE id = \\$4;").
-			WithArgs(file.Path, file.Size, file.Checksum, 42).
+		mock.ExpectExec("UPDATE local_ega.files SET status = 'ARCHIVED', archive_path = \\$1, archive_filesize = \\$2, inbox_file_checksum = \\$3, inbox_file_checksum_type = \\$4 WHERE id = \\$5;").
+			WithArgs(file.Path,
+				file.Size,
+				"96fa8f226d3801741e807533552bc4b177ac4544d834073b6a5298934d34b40b",
+				"SHA256",
+				42).
 			WillReturnResult(r)
 
 		return testDb.SetArchived(file, 42)
@@ -265,10 +306,11 @@ func TestSetArchived(t *testing.T) {
 
 	r = sqlTesterHelper(t, func(mock sqlmock.Sqlmock, testDb *SQLdb) error {
 
-		file := FileInfo{"10", 1000, "/tmp/file.c4gh"}
-
-		mock.ExpectExec("UPDATE local_ega.files SET status = 'ARCHIVED', archive_path = \\$1, archive_filesize = \\$2, inbox_file_checksum = \\$3, inbox_file_checksum_type = 'SHA256' WHERE id = \\$4;").
-			WithArgs(file.Path, file.Size, file.Checksum, 42).
+		mock.ExpectExec("UPDATE local_ega.files SET status = 'ARCHIVED', archive_path = \\$1, archive_filesize = \\$2, inbox_file_checksum = \\$3, inbox_file_checksum_type = \\$4 WHERE id = \\$5;").
+			WithArgs(file.Path,
+				file.Size,
+				"96fa8f226d3801741e807533552bc4b177ac4544d834073b6a5298934d34b40b",
+				"SHA256", 42).
 			WillReturnError(fmt.Errorf("error for testing"))
 
 		return testDb.SetArchived(file, 42)

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -326,7 +326,7 @@ func TestMarkReady(t *testing.T) {
 
 		r := sqlmock.NewResult(10, 1)
 
-		mock.ExpectExec("UPDATE local_ega.files SET status = 'READY', stable_id = \\$1 WHERE elixir_id = \\$2 and archive_path = \\$3 and archive_file_checksum = \\$4 and status != 'DISABLED';").
+		mock.ExpectExec("UPDATE local_ega.files SET status = 'READY', stable_id = \\$1 WHERE elixir_id = \\$2 and archive_path = \\$3 and decrypted_file_checksum = \\$4 and status != 'DISABLED';").
 			WithArgs("accessionId", "nobody", "/tmp/file.c4gh", "checksum").
 			WillReturnResult(r)
 
@@ -340,7 +340,7 @@ func TestMarkReady(t *testing.T) {
 
 	r = sqlTesterHelper(t, func(mock sqlmock.Sqlmock, testDb *SQLdb) error {
 
-		mock.ExpectExec("UPDATE local_ega.files SET status = 'READY', stable_id = \\$1 WHERE elixir_id = \\$2 and archive_path = \\$3 and archive_file_checksum = \\$4 and status != 'DISABLED';").
+		mock.ExpectExec("UPDATE local_ega.files SET status = 'READY', stable_id = \\$1 WHERE elixir_id = \\$2 and archive_path = \\$3 and decrypted_file_checksum = \\$4 and status != 'DISABLED';").
 			WithArgs("accessionId", "nobody", "/tmp/file.c4gh", "checksum").
 			WillReturnError(fmt.Errorf("error for testing"))
 

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -167,7 +167,7 @@ func TestMarkCompleted(t *testing.T) {
 		r := sqlmock.NewResult(10, 1)
 
 		mock.ExpectExec("UPDATE local_ega.files SET status = 'COMPLETED', "+
-			"archive_file_size = \\$2, "+
+			"archive_filesize = \\$2, "+
 			"archive_file_checksum = \\$3, "+
 			"archive_file_checksum_type = \\$4, "+
 			"decrypted_file_size = \\$5, "+
@@ -194,7 +194,7 @@ func TestMarkCompleted(t *testing.T) {
 	r = sqlTesterHelper(t, func(mock sqlmock.Sqlmock, testDb *SQLdb) error {
 
 		mock.ExpectExec("UPDATE local_ega.files SET status = 'COMPLETED', "+
-			"archive_file_size = \\$2, "+
+			"archive_filesize = \\$2, "+
 			"archive_file_checksum = \\$3, "+
 			"archive_file_checksum_type = \\$4, "+
 			"decrypted_file_size = \\$5, "+

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -150,8 +150,17 @@ func sqlTesterHelper(t *testing.T, f func(sqlmock.Sqlmock, *SQLdb) error) error 
 func TestMarkCompleted(t *testing.T) {
 	file := FileInfo{sha256.New(), 46, "/somepath", sha256.New(), 48}
 
-	file.Checksum.Write([]byte("checksum"))
-	file.DecryptedChecksum.Write([]byte("decryptedchecksum"))
+	_, err := file.Checksum.Write([]byte("checksum"))
+
+	if err != nil {
+		return
+	}
+
+	_, err = file.DecryptedChecksum.Write([]byte("decryptedchecksum"))
+
+	if err != nil {
+		return
+	}
 
 	r := sqlTesterHelper(t, func(mock sqlmock.Sqlmock, testDb *SQLdb) error {
 
@@ -280,7 +289,11 @@ func TestStoreHeader(t *testing.T) {
 func TestSetArchived(t *testing.T) {
 
 	file := FileInfo{sha256.New(), 1000, "/tmp/file.c4gh", sha256.New(), -1}
-	file.Checksum.Write([]byte("checksum"))
+	_, err := file.Checksum.Write([]byte("checksum"))
+
+	if err != nil {
+		return
+	}
 
 	r := sqlTesterHelper(t, func(mock sqlmock.Sqlmock, testDb *SQLdb) error {
 


### PR DESCRIPTION
Fixes #142.

Try to clean up some confusing naming issues as well - the database field `archive_file_checksum` now stores the checksum of what is actually stored in the archive rather than the decrypted checksum.

Decrypted checksum is stored in `decrypted_file_checksum`.

Sizes of archived and decrypted files are also kept (`archive_file_size` and `decrypted_file_size`).