### PR TITLE
Mq detect connection failure

### DIFF
--- a/cmd/finalize/finalize.go
+++ b/cmd/finalize/finalize.go
@@ -5,6 +5,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"sda-pipeline/internal/broker"
 	"sda-pipeline/internal/config"
@@ -55,6 +56,14 @@ func main() {
 	defer mq.Channel.Close()
 	defer mq.Connection.Close()
 	defer db.Close()
+
+	go func() {
+		for {
+			connError := broker.ConnectionWatcher(mq.Connection)
+			log.Error(connError)
+			os.Exit(1)
+		}
+	}()
 
 	ingestAccession := gojsonschema.NewReferenceLoader(conf.SchemasPath + "ingestion-accession.json")
 

--- a/cmd/ingest/ingest.go
+++ b/cmd/ingest/ingest.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 
 	"sda-pipeline/internal/broker"
 	"sda-pipeline/internal/config"
@@ -79,6 +80,14 @@ func main() {
 	defer mq.Channel.Close()
 	defer mq.Connection.Close()
 	defer db.Close()
+
+	go func() {
+		for {
+			connError := broker.ConnectionWatcher(mq.Connection)
+			log.Error(connError)
+			os.Exit(1)
+		}
+	}()
 
 	ingestTrigger := gojsonschema.NewReferenceLoader(conf.SchemasPath + "ingestion-trigger.json")
 

--- a/cmd/intercept/intercept.go
+++ b/cmd/intercept/intercept.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 
 	"sda-pipeline/internal/broker"
 	"sda-pipeline/internal/config"
@@ -33,6 +34,15 @@ func main() {
 
 	defer mq.Channel.Close()
 	defer mq.Connection.Close()
+
+
+	go func() {
+		for {
+			connError := broker.ConnectionWatcher(mq.Connection)
+			log.Error(connError)
+			os.Exit(1)
+		}
+	}()
 
 	forever := make(chan bool)
 

--- a/cmd/mapper/mapper.go
+++ b/cmd/mapper/mapper.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"encoding/json"
+	"os"
 
 	"sda-pipeline/internal/broker"
 	"sda-pipeline/internal/config"
@@ -37,6 +38,14 @@ func main() {
 	defer mq.Channel.Close()
 	defer mq.Connection.Close()
 	defer db.Close()
+
+	go func() {
+		for {
+			connError := broker.ConnectionWatcher(mq.Connection)
+			log.Error(connError)
+			os.Exit(1)
+		}
+	}()
 
 	datasetMapping := gojsonschema.NewReferenceLoader(conf.SchemasPath + "dataset-mapping.json")
 

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 
 	"sda-pipeline/internal/broker"
 	"sda-pipeline/internal/config"
@@ -71,6 +72,14 @@ func main() {
 	defer mq.Channel.Close()
 	defer mq.Connection.Close()
 	defer db.Close()
+
+	go func() {
+		for {
+			connError := broker.ConnectionWatcher(mq.Connection)
+			log.Error(connError)
+			os.Exit(1)
+		}
+	}()
 
 	ingestVerification := gojsonschema.NewReferenceLoader(conf.SchemasPath + "ingestion-verification.json")
 

--- a/dev_utils/compose-sda.yml
+++ b/dev_utils/compose-sda.yml
@@ -10,6 +10,7 @@ services:
       - ./:/dev_utils/
       - archive:/tmp
     mem_limit: 1024m
+    restart: always
   verify:
     command: sda-verify
     container_name: verify
@@ -19,7 +20,8 @@ services:
       - ./config.yaml:/config.yaml
       - ./:/dev_utils/
       - archive:/tmp
-#    mem_limit: 256m
+    mem_limit: 256m
+    restart: always
   finalize:
     command: sda-finalize
     container_name: finalize
@@ -29,6 +31,7 @@ services:
       - ./config.yaml:/config.yaml
       - ./:/dev_utils/
     mem_limit: 64m
+    restart: always
   mapper:
     command: sda-mapper
     container_name: mapper
@@ -38,6 +41,7 @@ services:
       - ./config.yaml:/config.yaml
       - ./:/dev_utils/
     mem_limit: 64m
+    restart: always
   interceptor:
     command: sda-intercept
     container_name: intercept
@@ -47,6 +51,7 @@ services:
       - ./config.yaml:/config.yaml
       - ./:/dev_utils/
     mem_limit: 64m
+    restart: always
 
 volumes:
      archive:

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -217,3 +217,10 @@ func confirmOne(confirms <-chan amqp.Confirmation) {
 	}
 	log.Debugf("confirmed delivery with delivery tag: %d", confirmed.DeliveryTag)
 }
+
+
+// ConnectionWatcher listens to events from the server 
+func ConnectionWatcher(conn *amqp.Connection) (*amqp.Error) {
+	amqpError := <-conn.NotifyClose(make(chan *amqp.Error))
+	return amqpError
+}


### PR DESCRIPTION
Simplest solution to the problem of MQ re-connectivity
* Detect if the MQ connection closes and exit the main process.
* Rely on the deployment system to restart a stopped application.

fixes #152 


If we want to keep the main  process running a major rewrite is required.