### PR TITLE
update actions go version

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,8 +1,3 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
 name: "CodeQL"
 
 on:
@@ -22,11 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Override automatic language detection by changing the below list
-        # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
         language: ['go']
-        # Learn more...
-        # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
 
     steps:
     - name: Checkout repository
@@ -46,26 +37,8 @@ jobs:
       uses: github/codeql-action/init@v1
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file. 
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       uses: github/codeql-action/autobuild@v1
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/create_docs.yaml
+++ b/.github/workflows/create_docs.yaml
@@ -21,7 +21,7 @@ jobs:
           ref: gh-pages
 
       - name: Set up Go 1.14
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: 1.14
         id: go

--- a/.github/workflows/create_docs.yaml
+++ b/.github/workflows/create_docs.yaml
@@ -20,10 +20,10 @@ jobs:
           path: gh-pages
           ref: gh-pages
 
-      - name: Set up Go 1.14
+      - name: Set up Go 1.15
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.15
         id: go
 
       - name: Get godoc

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: '3.6'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,15 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [1.14, 1.15]
     steps:
 
-      - name: Set up Go 1.14
-        uses: actions/setup-go@v1
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: ${{ matrix.go-version }}
         id: go
 
       - name: Check out code into the Go module directory


### PR DESCRIPTION
use go 1.14 and 1.15 to test
bump actions version for python and go
cleanup comments