### PR TITLE
Move to a unified ValidateJSON and fall-out from there

### DIFF
--- a/cmd/finalize/finalize_test.go
+++ b/cmd/finalize/finalize_test.go
@@ -1,11 +1,9 @@
 package main
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/spf13/viper"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -19,38 +17,4 @@ func TestConfigTestSuite(t *testing.T) {
 
 func (suite *TestSuite) SetupTest() {
 	viper.Set("log.level", "debug")
-}
-
-func (suite *TestSuite) TestValidateJSON_Accession() {
-	msg := finalize{
-		Type:        "accession",
-		User:        "foo",
-		Filepath:    "dummy_data.c4gh",
-		AccessionID: "EGAF12345678901",
-		DecryptedChecksums: []checksums{
-			{"sha256", "da886a89637d125ef9f15f6d676357f3a9e5e10306929f0bad246375af89c2e2"},
-		},
-	}
-	message, _ := json.Marshal(&msg)
-
-	res, err := validateJSON("file://../../schemas/federated/", message)
-	assert.Nil(suite.T(), err)
-	assert.True(suite.T(), res.Valid())
-}
-
-func (suite *TestSuite) TestValidateJSON_Completed() {
-	msg := completed{
-		User:        "foo",
-		Filepath:    "dummy_data.c4gh",
-		AccessionID: "EGAF12345678901",
-		DecryptedChecksums: []checksums{
-			{"sha256", "da886a89637d125ef9f15f6d676357f3a9e5e10306929f0bad246375af89c2e2"},
-			{"md5", "e3c19316a6f1cf8ef82a079a902e98d0"},
-		},
-	}
-	message, _ := json.Marshal(&msg)
-
-	res, err := validateJSON("file://../../schemas/federated/", message)
-	assert.Nil(suite.T(), err)
-	assert.True(suite.T(), res.Valid())
 }

--- a/cmd/ingest/ingest_test.go
+++ b/cmd/ingest/ingest_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"io"
 	"os"
 	"testing"
@@ -75,35 +74,4 @@ func (suite *TestSuite) TestTryDecrypt() {
 	b, err := tryDecrypt(key, buf)
 	assert.Equal(suite.T(), b, data)
 	assert.NoError(suite.T(), err)
-}
-
-func (suite *TestSuite) TestValidateJSON_Trigger() {
-	msg := trigger{
-		Type:     "ingest",
-		User:     "foo",
-		Filepath: "dummy_data.c4gh",
-	}
-	message, _ := json.Marshal(&msg)
-
-	res, err := validateJSON("file://../../schemas/federated/", message)
-	assert.Nil(suite.T(), err)
-	assert.True(suite.T(), res.Valid())
-}
-
-func (suite *TestSuite) TestValidateJSON_Archived() {
-	msg := archived{
-		User:     "foo",
-		FilePath: "dummy_data.c4gh",
-		FileID: 123,
-		ArchivePath: "09612f01-c1d0-4d84-9ada-bdd3324e580e",
-		EncryptedChecksums: []checksums{
-			{"sha256", "da886a89637d125ef9f15f6d676357f3a9e5e10306929f0bad246375af89c2e2"},
-		},
-		ReVerify: false,
-	}
-	message, _ := json.Marshal(&msg)
-
-	res, err := validateJSON("file://../../schemas/federated/", message)
-	assert.Nil(suite.T(), err)
-	assert.True(suite.T(), res.Valid())
 }

--- a/cmd/intercept/intercept.go
+++ b/cmd/intercept/intercept.go
@@ -99,6 +99,8 @@ func main() {
 	<-forever
 }
 
+// schemaNameFromType returns the schema to use for messages of
+// type msgType
 func schemaNameFromType(msgType string) (string, error) {
 	m := map[string]string{
 		msgAccession: "ingestion-accession",
@@ -114,6 +116,8 @@ func schemaNameFromType(msgType string) (string, error) {
 	return "", fmt.Errorf("Don't know what schema to use for %s", msgType)
 }
 
+// typeFromMessage returns the type value given a JSON structure for the message
+// supplied in body
 func typeFromMessage(body []byte) (string, error) {
 	message := make(map[string]interface{})
 	err := json.Unmarshal(body, &message)

--- a/cmd/intercept/intercept.go
+++ b/cmd/intercept/intercept.go
@@ -12,7 +12,6 @@ import (
 	"sda-pipeline/internal/config"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/xeipuuv/gojsonschema"
 )
 
 const (
@@ -52,36 +51,38 @@ func main() {
 		}
 		for delivered := range messages {
 			log.Debugf("received a message: %s", delivered.Body)
-			msgType, res, err := validateJSON(conf.SchemasPath, delivered.Body)
-			if res == nil {
-				continue
-			}
+
+			msgType, err := typeFromMessage(delivered.Body)
 			if err != nil {
-				log.Error(err)
-				// publish MQ error
-				continue
-			}
-			if !res.Valid() {
-				log.Error(res.Errors())
-				// publish MQ error
+				log.Errorf("Failed to get type for message "+
+					"(corr-id: %s, error: %v)",
+					delivered.CorrelationId,
+					err)
 				continue
 			}
 
-			var routingKey string
+			schema, err := schemaNameFromType(msgType)
 
-			switch msgType {
-			case msgAccession:
-				routingKey = "accessionIDs"
-			case msgCancel:
-				routingKey = ""
+			if err != nil {
+				log.Errorf("Don't know schema for %s", msgType)
 				continue
-			case msgIngest:
-				routingKey = "ingest"
-			case msgMapping:
-				routingKey = "mappings"
-			default:
-				log.Debug("Unknown type")
-				routingKey = ""
+			}
+
+			err = mq.ValidateJSON(&delivered, schema, delivered.Body, nil)
+
+			if err != nil {
+				continue
+			}
+
+			routing := map[string]string{
+				msgAccession: "accessionIDs",
+				msgIngest:    "ingest",
+				msgMapping:   "mappings",
+			}
+
+			routingKey := routing[msgType]
+
+			if routingKey == "" {
 				continue
 			}
 
@@ -98,46 +99,37 @@ func main() {
 	<-forever
 }
 
-// Validate the JSON in a received message
-func validateJSON(schemasPath string, body []byte) (string, *gojsonschema.Result, error) {
+func schemaNameFromType(msgType string) (string, error) {
+	m := map[string]string{
+		msgAccession: "ingestion-accession",
+		msgCancel:    "ingestion-trigger",
+		msgIngest:    "ingestion-trigger",
+		msgMapping:   "dataset-mapping",
+	}
+
+	if m[msgType] != "" {
+		return m[msgType], nil
+	}
+
+	return "", fmt.Errorf("Don't know what schema to use for %s", msgType)
+}
+
+func typeFromMessage(body []byte) (string, error) {
 	message := make(map[string]interface{})
 	err := json.Unmarshal(body, &message)
 	if err != nil {
-		return "", nil, err
+		return "", err
 	}
 
-	msgType, ok := message["type"]
+	msgTypeFetch, ok := message["type"]
 	if !ok {
-		return "", nil, errors.New("Malformed message, type is missing")
+		return "", errors.New("Malformed message, type is missing")
 	}
 
-	var schema gojsonschema.JSONLoader
-	var res *gojsonschema.Result
-
-	switch msgType {
-	case msgAccession:
-		schema = gojsonschema.NewReferenceLoader(schemasPath + "ingestion-accession.json")
-	case msgCancel:
-		schema = gojsonschema.NewReferenceLoader(schemasPath + "ingestion-trigger.json")
-		msgType = ""
-	case msgIngest:
-		schema = gojsonschema.NewReferenceLoader(schemasPath + "ingestion-trigger.json")
-	case msgMapping:
-		schema = gojsonschema.NewReferenceLoader(schemasPath + "dataset-mapping.json")
-	default:
-		schema = gojsonschema.NewStringLoader(`{"required": ["type"],
-												"properties": {
-														"type": {
-															"type": "string",
-															"title": "The message type",
-															"description": "The message type",
-															"enum": ["accession", "cancel", "ingest", "mapping"]
-														}
-													}
-												}`)
-		msgType = ""
+	msgType, ok := msgTypeFetch.(string)
+	if !ok {
+		return "", errors.New("Could not cast type attribute to string")
 	}
 
-	res, err = gojsonschema.Validate(schema, gojsonschema.NewBytesLoader(body))
-	return fmt.Sprintf("%v", msgType), res, err
+	return msgType, nil
 }

--- a/cmd/mapper/mapper_test.go
+++ b/cmd/mapper/mapper_test.go
@@ -1,11 +1,9 @@
 package main
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/spf13/viper"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -19,17 +17,4 @@ func TestConfigTestSuite(t *testing.T) {
 
 func (suite *TestSuite) SetupTest() {
 	viper.Set("log.level", "debug")
-}
-
-func (suite *TestSuite) TestValidateJSON_Mapping() {
-	msg := message{
-		Type:        "mapping",
-		DatasetID:   "EGAD12345678901",
-		AccessionIDs: []string{"EGAF12345678901", "EGAF12345678902",},
-	}
-	message, _ := json.Marshal(&msg)
-
-	res, err := validateJSON("file://../../schemas/federated/", message)
-	assert.Nil(suite.T(), err)
-	assert.True(suite.T(), res.Valid())
 }

--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -1,11 +1,9 @@
 package main
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/spf13/viper"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -19,37 +17,4 @@ func TestConfigTestSuite(t *testing.T) {
 
 func (suite *TestSuite) SetupTest() {
 	viper.Set("log.level", "debug")
-}
-
-func (suite *TestSuite) TestValidateJSON_Ingest() {
-	msg := message{
-		User:        "foo",
-		FileID:      123,
-		ArchivePath: "09612f01-c1d0-4d84-9ada-bdd3324e580e",
-		EncryptedChecksums: []checksums{
-			{"sha256", "da886a89637d125ef9f15f6d676357f3a9e5e10306929f0bad246375af89c2e2"},
-		},
-		ReVerify: false,
-	}
-	message, _ := json.Marshal(&msg)
-
-	res, err := validateJSON("file://../../schemas/federated/", message)
-	assert.Nil(suite.T(), err)
-	assert.True(suite.T(), res.Valid())
-}
-
-func (suite *TestSuite) TestValidateJSON_AccessionRequest() {
-	msg := verified{
-		User:     "foo",
-		FilePath: "dummy_data.c4gh",
-		DecryptedChecksums: []checksums{
-			{"sha256", "da886a89637d125ef9f15f6d676357f3a9e5e10306929f0bad246375af89c2e2"},
-			{"md5", "e3c19316a6f1cf8ef82a079a902e98d0"},
-		},
-	}
-	message, _ := json.Marshal(&msg)
-
-	res, err := validateJSON("file://../../schemas/federated/", message)
-	assert.Nil(suite.T(), err)
-	assert.True(suite.T(), res.Valid())
 }

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -261,6 +261,9 @@ func (broker *AMQPBroker) SendJSONError(delivered *amqp.Delivery, originalBody [
 	return broker.SendMessage(delivered.CorrelationId, conf.Exchange, conf.RoutingError, conf.Durable, body)
 }
 
+// ValidateJSON validates JSON in body, verifying that it's valid JSON as well
+// as conforming to the schema specified by messageType. It also optionally
+// verifies that the message can be decoded into the supplied data structure dest
 func (broker *AMQPBroker) ValidateJSON(delivered *amqp.Delivery,
 	messageType string,
 	body []byte,
@@ -344,7 +347,7 @@ func (broker *AMQPBroker) ValidateJSON(delivered *amqp.Delivery,
 	return err
 }
 
-// Validate the JSON in a received message
+// validateJSON is a helper function for ValidateJson
 func validateJSON(messageType string, schemasPath string, body []byte) (*gojsonschema.Result, error) {
 
 	schema := gojsonschema.NewReferenceLoader(schemasPath + "/" + messageType + ".json")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,11 +26,10 @@ var requiredConfVars []string
 
 // Config is a parent object for all the different configuration parts
 type Config struct {
-	Archive     storage.Conf
-	Broker      broker.MQConf
-	Inbox       storage.Conf
-	Database    database.DBConf
-	SchemasPath string
+	Archive  storage.Conf
+	Broker   broker.MQConf
+	Inbox    storage.Conf
+	Database database.DBConf
 }
 
 // NewConfig initializes and parses the config file and/or environment using
@@ -153,9 +152,9 @@ func NewConfig(app string) (*Config, error) {
 // the type IDs of connection Federated EGA or isolate (stand-alone)
 func (c *Config) configSchemas() {
 	if viper.GetString("schema.type") == "federated" {
-		c.SchemasPath = "file://schemas/federated/"
+		c.Broker.SchemasPath = "file://schemas/federated/"
 	} else {
-		c.SchemasPath = "file://schemas/isolated/"
+		c.Broker.SchemasPath = "file://schemas/isolated/"
 	}
 }
 


### PR DESCRIPTION
Validation/JSON handling moved to broker package.

The unmarshalling test is stricter now and will complain if fields
from the JSON is missing in the destination struct.

(I'm ambivalent as to whatever having JSON handling in broker or a new package, so feel free to say if you think it's better in a new package.)