### PR TITLE
Change dependabot to run weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
 - package-ecosystem: gomod
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 10
   reviewers:
     - "dbampalikis"


### PR DESCRIPTION
The AWS package are more or less being updated daily so to prevent spamming of PRs that just update one dependency we do a weekly set up dependency updates.