### PR TITLE
Update/ci actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,25 +1,36 @@
 version: 2
 updates:
-- package-ecosystem: docker
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-  reviewers:
-    - "dbampalikis"
-    - "jbygdell"
-    - "pontus"
-    - "jonandernovella"
-    - "blankdots"
-    - "dtitov"
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-  reviewers:
-    - "dbampalikis"
-    - "jbygdell"
-    - "pontus"
-    - "jonandernovella"
-    - "blankdots"
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    reviewers:
+      - "dbampalikis"
+      - "jbygdell"
+      - "pontus"
+      - "jonandernovella"
+      - "blankdots"
+      - "dtitov"
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    reviewers:
+      - "dbampalikis"
+      - "jbygdell"
+      - "pontus"
+      - "jonandernovella"
+      - "blankdots"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "dbampalikis"
+      - "jbygdell"
+      - "pontus"
+      - "jonandernovella"
+      - "blankdots"

--- a/.github/workflows/report.yaml
+++ b/.github/workflows/report.yaml
@@ -16,5 +16,5 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.32
+          version: v1.38
           args: -E gosec,goconst,nestif,interfacer,bodyclose,rowserrcheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.14, 1.15]
+        go-version: [1.14, 1.15, 1.16]
     steps:
 
       - name: Set up Go ${{ matrix.go-version }}

--- a/internal/broker/service_mock_test.go
+++ b/internal/broker/service_mock_test.go
@@ -85,14 +85,17 @@ type pipe struct {
 	w *io.PipeWriter
 }
 
+//nolint:deadcode,unused
 func (p pipe) Read(b []byte) (int, error) {
 	return p.r.Read(b)
 }
 
+//nolint:deadcode,unused
 func (p pipe) Write(b []byte) (int, error) {
 	return p.w.Write(b)
 }
 
+//nolint:deadcode,unused
 func (p pipe) Close() error {
 	p.r.Close()
 	p.w.Close()
@@ -106,6 +109,7 @@ type logIO struct {
 	proxy  io.ReadWriteCloser
 }
 
+//nolint:deadcode,unused
 func (log *logIO) Read(p []byte) (n int, err error) {
 	log.t.Logf("%s reading %d\n", log.prefix, len(p))
 	n, err = log.proxy.Read(p)
@@ -118,6 +122,7 @@ func (log *logIO) Read(p []byte) (n int, err error) {
 	return
 }
 
+//nolint:deadcode,unused
 func (log *logIO) Write(p []byte) (n int, err error) {
 	log.t.Logf("%s writing %d\n", log.prefix, len(p))
 	n, err = log.proxy.Write(p)
@@ -130,6 +135,7 @@ func (log *logIO) Write(p []byte) (n int, err error) {
 	return
 }
 
+//nolint:deadcode,unused
 func (log *logIO) Close() (err error) {
 	err = log.proxy.Close()
 	if err != nil {


### PR DESCRIPTION
- update dependabot to monitor github actions
- checks for golang 1.16, as our Dockerfile uses latest version always so good to test this newer version as well.
- bump golangci lint version
