### PR TITLE
update golang lint

### DIFF
--- a/.github/workflows/report.yaml
+++ b/.github/workflows/report.yaml
@@ -16,5 +16,5 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2.5.2
         with:
-          version: v1.38
-          args: -E gosec,goconst,nestif,interfacer,bodyclose,rowserrcheck
+          version: v1.42
+          args: -E gosec,goconst,nestif,bodyclose,rowserrcheck


### PR DESCRIPTION
bump golang-lint to 1.42