### PR TITLE
Changes to dev_utils

### DIFF
--- a/dev_utils/compose-backend.yml
+++ b/dev_utils/compose-backend.yml
@@ -70,6 +70,7 @@ services:
       - s3
     entrypoint: >
       /bin/sh -c "
+      sleep 10;
       /usr/bin/mc config host add s3 https://s3:9000 access secretkey;
       /usr/bin/mc mb s3/inbox;
       /usr/bin/mc mb s3/archive;


### PR DESCRIPTION
A few changes needed to make run_integration_test.sh work with the sda-pipeline when built using compose-backend.yml and compose-sda.yml