### PR TITLE
[HotFix] for stalled ingestions

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -236,19 +236,6 @@ func TLSConfigBroker(config MQConf) (*tls.Config, error) {
 	return &tlsConfig, nil
 }
 
-// confirmOne accepts confirmation for a message sent with reliable.
-//
-// One would typically keep a channel of publishings, a sequence number, and a
-// set of unacknowledged sequence numbers and loop until the publishing channel
-// is closed.
-func confirmOne(confirms <-chan amqp.Confirmation) {
-	confirmed := <-confirms
-	if !confirmed.Ack {
-		log.Errorf("failed delivery of delivery tag: %d", confirmed.DeliveryTag)
-	}
-	log.Debugf("confirmed delivery with delivery tag: %d", confirmed.DeliveryTag)
-}
-
 // ConnectionWatcher listens to events from the server
 func (broker *AMQPBroker) ConnectionWatcher() *amqp.Error {
 	amqpError := <-broker.Connection.NotifyClose(make(chan *amqp.Error))

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"sync"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
@@ -288,25 +287,6 @@ func TestTLSConfigBroker(t *testing.T) {
 	// Should we fail here?
 	//	assert.NotNil(t, err, "Expected failure was missing")
 
-}
-
-func TestConfirmOne(t *testing.T) {
-
-	var str bytes.Buffer
-	log.SetOutput(&str)
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-	c := make(chan amqp.Confirmation)
-	go func(c <-chan amqp.Confirmation) {
-		confirmOne(c)
-		assert.NotZero(t, str.Len(), "Expected warnings were missing")
-		assert.Contains(t, str.String(), "failed delivery of delivery tag")
-		wg.Done()
-	}(c)
-	c <- amqp.Confirmation{}
-
-	wg.Wait()
 }
 
 func TestValidateJSON(t *testing.T) {

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/streadway/amqp"
@@ -61,14 +60,14 @@ func (c *mockChannel) NotifyPublish(confirm chan amqp.Confirmation) chan amqp.Co
 
 func (c *mockChannel) Publish(exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error {
 
-	go func() {
-		time.Sleep(10000)
-		c.confirmChannel <- amqp.Confirmation{}
-	}()
-
 	if c.failPublish {
 		return fmt.Errorf("failPublish")
 	}
+
+	ack := amqp.Confirmation{}
+	ack.DeliveryTag = 1
+	ack.Ack = true
+	c.confirmChannel <- ack
 
 	return nil
 }
@@ -89,34 +88,16 @@ func TestGetMessages_Error(t *testing.T) {
 	assert.Error(t, err, "Must be an error")
 }
 
-func CatchSendMessage(b *AMQPBroker, corrID, exchange, routingkey string, reliable bool, body []byte) (err error) {
-	defer func() {
-		r := recover()
-		if r != nil {
-			err = fmt.Errorf("Caught panic")
-		}
-	}()
-	err = b.SendMessage(corrID, exchange, routingkey, reliable, body)
-
-	return err
-}
-
 func TestSendMessage(t *testing.T) {
-
 	b := AMQPBroker{}
 	c := mockChannel{}
 
 	var err error
-	c.failConfirm = true
 	b.Channel = &c
+	err = b.Channel.Confirm(false)
+	assert.Nil(t, err, "Could not Channle in confirm mode")
+	b.confirmsChan = b.Channel.NotifyPublish(make(chan amqp.Confirmation, 1))
 	msg := []byte("Message")
-
-	// Aborts run for some not yet understood reason
-
-	err = CatchSendMessage(&b, "corrID1", "exchange", "routingkey", true, msg)
-	assert.NotNil(t, err, "Unexpected non-error from SendMessage (reliable)")
-
-	c.failConfirm = false
 
 	err = b.SendMessage("corrID1", "exchange", "routingkey", false, msg)
 	assert.Nil(t, err, "Unexpected error from SendMessage (not reliable)")
@@ -164,20 +145,17 @@ func TestNewMQ(t *testing.T) {
 	noSslConf.Port = noSSLPort
 
 	go handleOneConnection(s.Sessions, false, false)
-	b, _ := NewMQ(noSslConf)
-
+	b, e := NewMQ(noSslConf)
+	assert.Nil(t, e, "Unwanted Error")
 	assert.NotNil(t, b, "NewMQ without ssl did not return a broker")
-
 	// Fail the queuedeclarepassive
 	go handleOneConnection(s.Sessions, false, true)
 	errret := CatchNewMQPanic(t, noSslConf)
 	assert.NotNil(t, errret, "NewMQ did fail as expected")
-
 	// Fail the channel
 	go handleOneConnection(s.Sessions, true, true)
 	errret = CatchNewMQPanic(t, noSslConf)
 	assert.NotNil(t, errret, "NewMQ did fail as expected")
-
 	s.Close()
 
 	sslConf := tMqconf
@@ -186,10 +164,10 @@ func TestNewMQ(t *testing.T) {
 	sslConf.Port = sslPort
 	sslConf.ServerName = sslConf.Host
 
-	serverTlsConfig := tlsServerConfig()
-	serverTlsConfig.ClientAuth = tls.NoClientCert
+	serverTLSConfig := tlsServerConfig()
+	serverTLSConfig.ClientAuth = tls.NoClientCert
 
-	ss := startTLSServer(t, sslPort, serverTlsConfig)
+	ss := startTLSServer(t, sslPort, serverTLSConfig)
 
 	go handleOneConnection(ss.Sessions, false, false)
 

--- a/internal/broker/service_mock_test.go
+++ b/internal/broker/service_mock_test.go
@@ -229,9 +229,8 @@ func handleOneConnection(s chan *commonServer, failChannel, failDeclare bool) {
 	if failChannel == true {
 		session.send(1, &channelClose{ReplyCode: 506, ReplyText: "Something", MethodID: 10, ClassID: 20})
 		return
-	} else {
-		session.send(1, &channelOpenOk{})
 	}
+	session.send(1, &channelOpenOk{})
 
 	qD := queueDeclare{}
 	session.recv(1, &qD)
@@ -239,9 +238,12 @@ func handleOneConnection(s chan *commonServer, failChannel, failDeclare bool) {
 	if failDeclare == true {
 		session.send(1, &channelClose{ReplyCode: 506,
 			ReplyText: "Something", MethodID: 10, ClassID: 50})
-	} else {
-		session.send(1, &queueDeclareOk{})
+		return
 	}
+	session.send(1, &queueDeclareOk{})
+
+	session.recv(1, &confirmSelect{})
+	session.send(1, &confirmSelectOk{})
 
 	//	session.connectionClose()
 	//	session.S.Close()


### PR DESCRIPTION
By moving the creation of the NotifyPublish channel to the main MQ channel creation, instead of message publishing a deadlock is prevented. For some reason the channel was not cleared by listening on the response.