### PR TITLE
Feature/add shellcheck action #none

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,24 +6,18 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     reviewers:
-      - "dbampalikis"
-      - "jbygdell"
-      - "blankdots"
+      - "neicnordic/sensitive-data-development-collaboration"
   - package-ecosystem: gomod
     directory: "/"
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
     reviewers:
-      - "dbampalikis"
-      - "jbygdell"
-      - "blankdots"
+      - "neicnordic/sensitive-data-development-collaboration"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
     reviewers:
-      - "dbampalikis"
-      - "jbygdell"
-      - "blankdots"
+      - "neicnordic/sensitive-data-development-collaboration"

--- a/.github/integration/setup/common/10_services.sh
+++ b/.github/integration/setup/common/10_services.sh
@@ -14,7 +14,7 @@ if [ "$STORAGETYPE" = s3 ]; then
     tostart="mq db s3 certfixer"
 fi
 
-# we need to let it be split here otherwise it takes it as one
+# We need to leave the $tostart variable unquoted here since we want it to split
 # shellcheck disable=SC2086
 docker-compose -f compose-backend.yml up -d $tostart
 

--- a/.github/integration/setup/common/10_services.sh
+++ b/.github/integration/setup/common/10_services.sh
@@ -14,19 +14,21 @@ if [ "$STORAGETYPE" = s3 ]; then
     tostart="mq db s3 certfixer"
 fi
 
+# we need to let it be split here otherwise it takes it as one
+# shellcheck disable=SC2086
 docker-compose -f compose-backend.yml up -d $tostart
 
 RETRY_TIMES=0
 for p in $tostart; do
-    if [ $p = "certfixer" ]; then
+    if [ "$p" = "certfixer" ]; then
         continue
     fi
-    until docker ps -f name=$p --format "{{.Status}}" | grep "(healthy)"
+    until docker ps -f name="$p" --format "{{.Status}}" | grep "(healthy)"
     do echo "waiting for $p to become ready"
         RETRY_TIMES=$((RETRY_TIMES+1));
         if [ "$RETRY_TIMES" -eq 30 ]; then
         # Time out
-        docker logs $p
+        docker logs "$p"
             exit 1;
             fi
         sleep 10
@@ -37,7 +39,7 @@ docker-compose -f compose-sda.yml up -d
 
 RETRY_TIMES=0
 for p in ingest verify finalize mapper intercept; do
-    until docker ps -f name=$p --format "{{.Status}}" | grep "Up"
+    until docker ps -f name="$p" --format "{{.Status}}" | grep "Up"
     do echo "waiting for $p to become ready"
         RETRY_TIMES=$((RETRY_TIMES+1));
         if [ "$RETRY_TIMES" -eq 30 ]; then

--- a/.github/integration/tests/common/10_trigger_failures.sh
+++ b/.github/integration/tests/common/10_trigger_failures.sh
@@ -11,7 +11,7 @@ exit 0
 
 curl --cacert dev_utils/certs/ca.pem  -vvv -u test:test 'https://localhost:15672/api/exchanges/test/sda/publish' \
      -H 'Content-Type: application/json;charset=UTF-8' \
-     --data-binary "$( echo '{
+     --data-binary '{
     	                       "vhost":"test",
                                "name":"sda",
     	                       "properties":{
@@ -35,7 +35,7 @@ curl --cacert dev_utils/certs/ca.pem  -vvv -u test:test 'https://localhost:15672
     	                                                            }
     	                                                           ]
     	                                  }"
-    	                      }' )"
+    	                      }'
 
 
 # Verify message put in error here once https://github.com/neicnordic/sda-pipeline/issues/130 is resolved.
@@ -50,7 +50,7 @@ curl --cacert dev_utils/certs/ca.pem  -u test:test 'https://localhost:15672/api/
 
 curl --cacert dev_utils/certs/ca.pem  -vvv -u test:test 'https://localhost:15672/api/exchanges/test/sda/publish' \
      -H 'Content-Type: application/json;charset=UTF-8' \
-     --data-binary "$( echo '{
+     --data-binary '{
     	                       "vhost":"test",
                                "name":"sda",
     	                       "properties":{
@@ -74,7 +74,7 @@ curl --cacert dev_utils/certs/ca.pem  -vvv -u test:test 'https://localhost:15672
     	                                                            }
     	                                                           ]
     	                                  }"
-    	                      }' )"
+    	                      }'
 
 
 # Verify message put in error here once https://github.com/neicnordic/sda-pipeline/issues/130 is resolved.

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - name: Set up Python
         uses: actions/setup-python@v2
-        with:
-          python-version: '3.6'
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,17 @@
+name: Scripts linter
+
+on:
+  push:
+    branches:    
+      - '**'        # matches every branch
+      - '!master'   # excludes master
+
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run ShellCheck
+      uses: ludeeus/action-shellcheck@master

--- a/dev_utils/make_certs.sh
+++ b/dev_utils/make_certs.sh
@@ -3,23 +3,23 @@
 mkdir -p certs
 
 # create CA certificate
-openssl req -config "$(dirname $0)"/ssl.cnf -new -sha256 -nodes -extensions v3_ca -out ./certs/ca.csr -keyout ./certs/ca-key.pem
-openssl req -config "$(dirname $0)"/ssl.cnf -key ./certs/ca-key.pem -x509 -new -days 7300 -sha256 -nodes -extensions v3_ca -out ./certs/ca.pem
+openssl req -config "$(dirname "$0")"/ssl.cnf -new -sha256 -nodes -extensions v3_ca -out ./certs/ca.csr -keyout ./certs/ca-key.pem
+openssl req -config "$(dirname "$0")"/ssl.cnf -key ./certs/ca-key.pem -x509 -new -days 7300 -sha256 -nodes -extensions v3_ca -out ./certs/ca.pem
 
 # Create certificate for MQ
-openssl req -config "$(dirname $0)"/ssl.cnf -new -nodes -newkey rsa:4096 -keyout ./certs/mq-key.pem -out ./certs/mq.csr -extensions server_cert
-openssl x509 -req -in ./certs/mq.csr -days 1200 -CA ./certs/ca.pem -CAkey ./certs/ca-key.pem -set_serial 01 -out ./certs/mq.pem -extensions server_cert -extfile "$(dirname $0)"/ssl.cnf
+openssl req -config "$(dirname "$0")"/ssl.cnf -new -nodes -newkey rsa:4096 -keyout ./certs/mq-key.pem -out ./certs/mq.csr -extensions server_cert
+openssl x509 -req -in ./certs/mq.csr -days 1200 -CA ./certs/ca.pem -CAkey ./certs/ca-key.pem -set_serial 01 -out ./certs/mq.pem -extensions server_cert -extfile "$(dirname "$0")"/ssl.cnf
 
 # Create certificate for DB
-openssl req -config "$(dirname $0)"/ssl.cnf -new -nodes -newkey rsa:4096 -keyout ./certs/db-key.pem -out ./certs/db.csr -extensions server_cert
-openssl x509 -req -in ./certs/db.csr -days 1200 -CA ./certs/ca.pem -CAkey ./certs/ca-key.pem -set_serial 01 -out ./certs/db.pem -extensions server_cert -extfile "$(dirname $0)"/ssl.cnf
+openssl req -config "$(dirname "$0")"/ssl.cnf -new -nodes -newkey rsa:4096 -keyout ./certs/db-key.pem -out ./certs/db.csr -extensions server_cert
+openssl x509 -req -in ./certs/db.csr -days 1200 -CA ./certs/ca.pem -CAkey ./certs/ca-key.pem -set_serial 01 -out ./certs/db.pem -extensions server_cert -extfile "$(dirname "$0")"/ssl.cnf
 
 # Create certificate for minio
-openssl req -config "$(dirname $0)"/ssl.cnf -new -nodes -newkey rsa:4096 -keyout ./certs/s3-key.pem -out ./certs/s3.csr -extensions server_cert
-openssl x509 -req -in ./certs/s3.csr -days 1200 -CA ./certs/ca.pem -CAkey ./certs/ca-key.pem -set_serial 01 -out ./certs/s3.pem -extensions server_cert -extfile "$(dirname $0)"/ssl.cnf
+openssl req -config "$(dirname "$0")"/ssl.cnf -new -nodes -newkey rsa:4096 -keyout ./certs/s3-key.pem -out ./certs/s3.csr -extensions server_cert
+openssl x509 -req -in ./certs/s3.csr -days 1200 -CA ./certs/ca.pem -CAkey ./certs/ca-key.pem -set_serial 01 -out ./certs/s3.pem -extensions server_cert -extfile "$(dirname "$0")"/ssl.cnf
 
 # Create client certificate
-openssl req -config "$(dirname $0)"/ssl.cnf -new -nodes -newkey rsa:4096 -keyout ./certs/client-key.pem -out ./certs/client.csr -extensions client_cert
-openssl x509 -req -in ./certs/client.csr -days 1200 -CA ./certs/ca.pem -CAkey ./certs/ca-key.pem -set_serial 01 -out ./certs/client.pem -extensions client_cert -extfile "$(dirname $0)"/ssl.cnf
+openssl req -config "$(dirname "$0")"/ssl.cnf -new -nodes -newkey rsa:4096 -keyout ./certs/client-key.pem -out ./certs/client.csr -extensions client_cert
+openssl x509 -req -in ./certs/client.csr -days 1200 -CA ./certs/ca.pem -CAkey ./certs/ca-key.pem -set_serial 01 -out ./certs/client.pem -extensions client_cert -extfile "$(dirname "$0")"/ssl.cnf
 
 chmod 644 ./certs/*

--- a/dev_utils/run_tests.sh
+++ b/dev_utils/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-cd "$(dirname "$0")"
+cd "$(dirname "$0")" || exit
 
 docker-compose -f compose-sda.yml down -v --remove-orphans
 docker-compose -f compose-backend.yml down -v --remove-orphans
@@ -12,6 +12,7 @@ tmpdir=$(mktemp -d)
 
 # Set up a scratch python environment to not pollute anything else
 python3 -m venv "$tmpdir"
+# shellcheck disable=SC1091
 . "$tmpdir/bin/activate"
 
 export STORAGETYPE
@@ -20,7 +21,7 @@ for storage in s3 posix; do
 
     STORAGETYPE=$storage
 
-    for runscript in $(ls -1 .github/integration/setup/{common,${storage}}/*.sh 2>/dev/null | sort -t/ -k5 -n); do
+    for runscript in $(find . -maxdepth 1 -name ".github/integration/setup/{common,${storage}}/*.sh" 2>/dev/null | sort -t/ -k5 -n); do
 	echo "Executing setup script $runscript";
 	if bash -x "$runscript"; then
 	    :
@@ -31,7 +32,7 @@ for storage in s3 posix; do
 	fi
     done
     
-    for runscript in $(ls -1 .github/integration/tests/{common,${storage}}/*.sh 2>/dev/null | sort -t/ -k5 -n); do
+    for runscript in $(find . -maxdepth 1 -name ".github/integration/tests/{common,${storage}}/*.sh" 2>/dev/null | sort -t/ -k5 -n); do
 	echo "Executing test script $runscript";
 	if bash -x "$runscript"; then
 	    :


### PR DESCRIPTION
Closes #322 
changes:
- adjust shell scripts with a uniform syntax
- add shellcheck github action that runs only on all branches except master
- don't require python 3.6 as default version in integration tests
- tag whole team for checking dependency updates