### PR TITLE
Update dependbot.yml to add neic team as reviewers #none

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,24 +6,18 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     reviewers:
-      - "dbampalikis"
-      - "jbygdell"
-      - "blankdots"
+      - "neicnordic/sensitive-data-development-collaboration"
   - package-ecosystem: gomod
     directory: "/"
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
     reviewers:
-      - "dbampalikis"
-      - "jbygdell"
-      - "blankdots"
+      - "neicnordic/sensitive-data-development-collaboration"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
     reviewers:
-      - "dbampalikis"
-      - "jbygdell"
-      - "blankdots"
+      - "neicnordic/sensitive-data-development-collaboration"


### PR DESCRIPTION
Updated the `.github/dependabot.yml` to include the whole team as reviewers in pull requests.