### PR TITLE
Refactor/handle improper uploads

### DIFF
--- a/.github/integration/setup/common/10_services.sh
+++ b/.github/integration/setup/common/10_services.sh
@@ -72,5 +72,5 @@ else
 fi
 
 # Show running containers
-docker ps -a
+docker ps
 

--- a/.github/integration/setup/common/22_create_and_encrypt_large_file.sh
+++ b/.github/integration/setup/common/22_create_and_encrypt_large_file.sh
@@ -17,3 +17,14 @@ touch empty.c4gh
 
 dd if=largefile.c4gh bs=1 count="$((15000+RANDOM))" of=truncated1.c4gh
 dd if=largefile.c4gh bs=1 count=10 of=truncated2.c4gh
+
+dd if=/dev/random of=wrongly_encrypted.raw count=1 bs=$(( 1024 * 1024 *  1 )) iflag=fullblock
+
+cat > wrong_key.pub <<EOF
+-----BEGIN CRYPT4GH PUBLIC KEY-----
+fGi6kvZlQN37PLmumygbNaSLf0NA+kj4KB1b70HFFCU=
+-----END CRYPT4GH PUBLIC KEY-----
+EOF
+
+crypt4gh encrypt --recipient_pk wrong_key.pub < wrongly_encrypted.raw > wrongly_encrypted.c4gh
+rm wrongly_encrypted.raw wrong_key.pub

--- a/.github/integration/setup/common/22_create_and_encrypt_large_file.sh
+++ b/.github/integration/setup/common/22_create_and_encrypt_large_file.sh
@@ -20,11 +20,17 @@ dd if=largefile.c4gh bs=1 count=10 of=truncated2.c4gh
 
 dd if=/dev/random of=wrongly_encrypted.raw count=1 bs=$(( 1024 * 1024 *  1 )) iflag=fullblock
 
-cat > wrong_key.pub <<EOF
------BEGIN CRYPT4GH PUBLIC KEY-----
-fGi6kvZlQN37PLmumygbNaSLf0NA+kj4KB1b70HFFCU=
------END CRYPT4GH PUBLIC KEY-----
-EOF
+/usr/bin/expect <<EOD
+spawn crypt4gh-keygen --sk wrong_key.key --pk wrong_key.pub
+match_max 100000
+expect -exact "Generating public/private Crypt4GH key pair.\r
+Enter passphrase for wrong_key.key (empty for no passphrase): "
+send -- "secret\r"
+expect -exact "\r
+Enter passphrase for wrong_key.key (again): "
+send -- "secret\r"
+expect eof
+EOD
 
 crypt4gh encrypt --recipient_pk wrong_key.pub < wrongly_encrypted.raw > wrongly_encrypted.c4gh
-rm wrongly_encrypted.raw wrong_key.pub
+rm -f wrongly_encrypted.raw wrong_key.pub wrong_key.key

--- a/.github/integration/setup/s3/100_s3_storage_setup.sh
+++ b/.github/integration/setup/s3/100_s3_storage_setup.sh
@@ -4,7 +4,7 @@ pip3 install s3cmd
 
 cd dev_utils || exit 1
 
-# Make buckets if they don't exist already 
+# Make buckets if they don't exist already
 s3cmd -c s3cmd.conf mb s3://inbox || true
 s3cmd -c s3cmd.conf mb s3://archive || true
 
@@ -14,3 +14,4 @@ s3cmd -c s3cmd.conf put largefile.c4gh s3://inbox/largefile.c4gh
 s3cmd -c s3cmd.conf put empty.c4gh s3://inbox/empty.c4gh
 s3cmd -c s3cmd.conf put truncated1.c4gh s3://inbox/truncated1.c4gh
 s3cmd -c s3cmd.conf put truncated2.c4gh s3://inbox/truncated2.c4gh
+s3cmd -c s3cmd.conf put wrongly_encrypted.c4gh s3://inbox/wrongly_encrypted.c4gh

--- a/.github/integration/setup/s3notls/99_s3_storage_setup.sh
+++ b/.github/integration/setup/s3notls/99_s3_storage_setup.sh
@@ -4,7 +4,7 @@ pip3 install s3cmd
 
 cd dev_utils || exit 1
 
-# Make buckets if they don't exist already 
+# Make buckets if they don't exist already
 s3cmd -c s3cmd-notls.conf mb s3://inbox || true
 s3cmd -c s3cmd-notls.conf mb s3://archive || true
 
@@ -14,3 +14,4 @@ s3cmd -c s3cmd-notls.conf put largefile.c4gh s3://inbox/largefile.c4gh
 s3cmd -c s3cmd-notls.conf put empty.c4gh s3://inbox/empty.c4gh
 s3cmd -c s3cmd-notls.conf put truncated1.c4gh s3://inbox/truncated1.c4gh
 s3cmd -c s3cmd-notls.conf put truncated2.c4gh s3://inbox/truncated2.c4gh
+s3cmd -c s3cmd-notls.conf put wrongly_encrypted.c4gh s3://inbox/wrongly_encrypted.c4gh

--- a/cmd/ingest/ingest.go
+++ b/cmd/ingest/ingest.go
@@ -145,7 +145,7 @@ func main() {
 					err)
 				// Nack message so the server gets notified that something is wrong and requeue the message
 				if e := delivered.Nack(false, true); e != nil {
-					log.Errorln("Failed to Nack message (failed get file size) "+
+					log.Errorf("Failed to Nack message (failed get file size) "+
 						"(corr-id: %s, user: %s, filepath: %s, reason: %v)",
 						delivered.CorrelationId,
 						message.User,
@@ -160,7 +160,7 @@ func main() {
 				}
 				body, _ := json.Marshal(fileError)
 				if e := mq.SendMessage(delivered.CorrelationId, conf.Broker.Exchange, conf.Broker.RoutingError, conf.Broker.Durable, body); e != nil {
-					log.Error("Failed to publish message (get file size error), to error queue "+
+					log.Errorf("Failed to publish message (get file size error), to error queue "+
 						"(corr-id: %s, user: %s, filepath: %s, reason: %v)",
 						delivered.CorrelationId,
 						message.User,
@@ -191,7 +191,7 @@ func main() {
 					err)
 				// Nack message so the server gets notified that something is wrong and requeue the message
 				if e := delivered.Nack(false, true); e != nil {
-					log.Errorln("Failed to Nack message (archive file crate error) "+
+					log.Errorf("Failed to Nack message (archive file crate error) "+
 						"(corr-id: %s, user: %s, filepath: %s, archivepath: %s, reason: %v)",
 						delivered.CorrelationId,
 						message.User,
@@ -252,7 +252,7 @@ func main() {
 				if bytesRead <= int64(len(readBuffer)) {
 					header, err := tryDecrypt(key, readBuffer)
 					if err != nil {
-						log.Errorln("Trying to decrypt start of file failed "+
+						log.Errorf("Trying to decrypt start of file failed "+
 							"(corr-id: %s, user: %s, filepath: %s, archivepath: %s, reason: %v)",
 							delivered.CorrelationId,
 							message.User,
@@ -362,7 +362,7 @@ func main() {
 			fileInfo.Size, err = archive.GetFileSize(archivedFile)
 
 			if err != nil {
-				log.Error("Couldn't get file size from archive for verification "+
+				log.Errorf("Couldn't get file size from archive for verification "+
 					"(corr-id: %s, user: %s, filepath: %s, archivepath: %s, reason: %v)",
 					delivered.CorrelationId,
 					message.User,


### PR DESCRIPTION
Messages that concern uploads of wrongly encrypted files used to linger at the ingest queue. 

- These are now nacked and moved to the error queue, freeing up more consume resources and  improving overall performance of the ingest service.
- fixed some log formatting issues along the way