### PR TITLE
Refactor/ingest nack checks

### DIFF
--- a/.github/integration/tests/common/10_trigger_failures.sh
+++ b/.github/integration/tests/common/10_trigger_failures.sh
@@ -13,10 +13,10 @@ exit 0
 
 function check_move_to_error_queue() {
 	now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-	echo $now
+	echo "$now"
 	RETRY_TIMES=0
 	echo
-	echo "Waiting for msg containing \""$1"\" to move to error queue."
+	echo "Waiting for msg containing \"""$1""\" to move to error queue."
 	until curl --cacert certs/ca.pem  -u test:test 'https://localhost:15672/api/queues/test/error/get' \
 		-H 'Content-Type: application/json;charset=UTF-8' \
 		-d '{"count":1,"ackmode":"ack_requeue_false","encoding":"auto","truncate":50000}' 2>&1 | grep -q "$1"; do
@@ -33,7 +33,7 @@ function check_move_to_error_queue() {
 		sleep 2
 	done
 	echo
-	echo "Message with \""$1"\" moved to error queue."
+	echo "Message with \"""$1""\" moved to error queue."
 }
 
 # Submit a file encrypted with the wrong key

--- a/.github/integration/tests/common/10_trigger_failures.sh
+++ b/.github/integration/tests/common/10_trigger_failures.sh
@@ -35,6 +35,7 @@ function check_move_to_error_queue() {
 	echo
 	echo "Message with \""$1"\" moved to error queue."
 }
+
 # Submit a file encrypted with the wrong key
 
 md5sum=$(md5sum wrongly_encrypted.c4gh | cut -d' ' -f 1)
@@ -107,6 +108,8 @@ curl --cacert certs/ca.pem  -vvv -u test:test 'https://localhost:15672/api/excha
 
 check_move_to_error_queue "NoSuchKey: The specified key does not exist."
 
+: <<'END_COMMENT'
+# (currently not implemented)
 # Submit an existing file but incorrect checksum
 
 curl --cacert certs/ca.pem  -vvv -u test:test 'https://localhost:15672/api/exchanges/test/sda/publish' \
@@ -144,6 +147,7 @@ curl --cacert certs/ca.pem  -u test:test 'https://localhost:15672/api/queues/tes
 		   -H 'Content-Type: application/json;charset=UTF-8' \
 		   -d '{"count":1,"ackmode":"ack_requeue_true","encoding":"auto","truncate":50000}'
 
+END_COMMENT
 
 # Submit a truncated file (with correct checksum)
 

--- a/.github/integration/tests/common/10_trigger_failures.sh
+++ b/.github/integration/tests/common/10_trigger_failures.sh
@@ -19,7 +19,7 @@ function check_move_to_error_queue() {
 	echo "Waiting for msg containing \""$1"\" to move to error queue."
 	until curl --cacert certs/ca.pem  -u test:test 'https://localhost:15672/api/queues/test/error/get' \
 		-H 'Content-Type: application/json;charset=UTF-8' \
-		-d '{"count":1,"ackmode":"ack_requeue_true","encoding":"auto","truncate":50000}' 2>&1 | grep -q "$1"; do
+		-d '{"count":1,"ackmode":"ack_requeue_false","encoding":"auto","truncate":50000}' 2>&1 | grep -q "$1"; do
 		printf '%s' "."
 		RETRY_TIMES=$((RETRY_TIMES + 1))
 		if [ $RETRY_TIMES -eq 61 ]; then
@@ -103,11 +103,9 @@ curl --cacert certs/ca.pem  -vvv -u test:test 'https://localhost:15672/api/excha
     	                      }'
 
 
-# Verify message put in error here once https://github.com/neicnordic/sda-pipeline/issues/130 is resolved.
+# Verify that message is moved to the error queue (takes a few mins).
 
-curl --cacert certs/ca.pem  -u test:test 'https://localhost:15672/api/queues/test/error/get' \
-		   -H 'Content-Type: application/json;charset=UTF-8' \
-		   -d '{"count":1,"ackmode":"ack_requeue_true","encoding":"auto","truncate":50000}'
+check_move_to_error_queue "NoSuchKey: The specified key does not exist."
 
 # Submit an existing file but incorrect checksum
 

--- a/.github/integration/tests/common/10_trigger_failures.sh
+++ b/.github/integration/tests/common/10_trigger_failures.sh
@@ -182,12 +182,9 @@ curl --cacert certs/ca.pem  -vvv -u test:test 'https://localhost:15672/api/excha
     	                                  }"
     	                      }' | sed -e "s/SHA256SUM/${sha256sum}/" -e "s/MD5SUM/${md5sum}/" )"
 
-# Verify message put in error here once https://github.com/neicnordic/sda-pipeline/issues/130 is resolved.
+# Verify that message is moved to the error queue.
 
-curl --cacert certs/ca.pem  -u test:test 'https://localhost:15672/api/queues/test/error/get' \
-		   -H 'Content-Type: application/json;charset=UTF-8' \
-		   -d '{"count":1,"ackmode":"ack_requeue_true","encoding":"auto","truncate":50000}'
-
+check_move_to_error_queue "data segment can't be decrypted with any of header keys"
 
 # Submit a smaller truncated file (with correct checksum)
 
@@ -222,11 +219,9 @@ curl --cacert certs/ca.pem  -vvv -u test:test 'https://localhost:15672/api/excha
     	                                  }"
     	                      }' | sed -e "s/SHA256SUM/${sha256sum}/" -e "s/MD5SUM/${md5sum}/" )"
 
-# Verify message put in error here once https://github.com/neicnordic/sda-pipeline/issues/130 is resolved.
+# Verify that message is moved to the error queue.
 
-curl --cacert certs/ca.pem  -u test:test 'https://localhost:15672/api/queues/test/error/get' \
-		   -H 'Content-Type: application/json;charset=UTF-8' \
-		   -d '{"count":1,"ackmode":"ack_requeue_true","encoding":"auto","truncate":50000}'
+check_move_to_error_queue "unexpected EOF"
 
 
 # Cleanup cueues

--- a/cmd/ingest/ingest.go
+++ b/cmd/ingest/ingest.go
@@ -143,7 +143,8 @@ func main() {
 					message.User,
 					message.Filepath,
 					err)
-				// Nack message so the server gets notified that something is wrong and requeue the message
+				// Nack message so the server gets notified that something is wrong and requeue the message.
+				// Since reading the file worked, this should eventually succeed so it is ok to requeue.
 				if e := delivered.Nack(false, true); e != nil {
 					log.Errorf("Failed to Nack message (failed get file size) "+
 						"(corr-id: %s, user: %s, filepath: %s, reason: %v)",
@@ -189,9 +190,10 @@ func main() {
 					message.Filepath,
 					archivedFile,
 					err)
-				// Nack message so the server gets notified that something is wrong and requeue the message
+				// Nack message so the server gets notified that something is wrong and requeue the message.
+				// NewFileWriter returns an error when the backend itself fails so this is reasonable to requeue.
 				if e := delivered.Nack(false, true); e != nil {
-					log.Errorf("Failed to Nack message (archive file crate error) "+
+					log.Errorf("Failed to Nack message (archive file create error) "+
 						"(corr-id: %s, user: %s, filepath: %s, archivepath: %s, reason: %v)",
 						delivered.CorrelationId,
 						message.User,

--- a/cmd/ingest/ingest.go
+++ b/cmd/ingest/ingest.go
@@ -265,10 +265,11 @@ func main() {
 						// Nack message so the server gets notified that something is wrong. Do not requeue the message.
 						if e := delivered.Nack(false, false); e != nil {
 							log.Errorf("Failed to Nack message (failed decrypt file) "+
-								"(corr-id: %s, user: %s, filepath: %s, reason: %v)",
+								"(corr-id: %s, user: %s, filepath: %s, archivepath: %s, reason: %v)",
 								delivered.CorrelationId,
 								message.User,
 								message.Filepath,
+								archivedFile,
 								e)
 						}
 

--- a/cmd/ingest/ingest.go
+++ b/cmd/ingest/ingest.go
@@ -132,6 +132,31 @@ func main() {
 					message.User,
 					message.Filepath,
 					err)
+				// Nack message so the server gets notified that something is wrong. Do not requeue the message.
+				if e := delivered.Nack(false, false); e != nil {
+					log.Errorf("Failed to Nack message (failed to open file to ingest) "+
+						"(corr-id: %s, user: %s, filepath: %s, reason: %v)",
+						delivered.CorrelationId,
+						message.User,
+						message.Filepath,
+						e)
+				}
+				// Send the message to an error queue so it can be analyzed.
+				fileError := broker.FileError{
+					User:     message.User,
+					FilePath: message.Filepath,
+					Reason:   err.Error(),
+				}
+				body, _ := json.Marshal(fileError)
+				if e := mq.SendMessage(delivered.CorrelationId, conf.Broker.Exchange, conf.Broker.RoutingError, conf.Broker.Durable, body); e != nil {
+					log.Errorf("Failed to publish message (open file to ingest error), to error queue "+
+						"(corr-id: %s, user: %s, filepath: %s, reason: %v)",
+						delivered.CorrelationId,
+						message.User,
+						message.Filepath,
+						e)
+				}
+				// Restart on new message
 				continue
 			}
 


### PR DESCRIPTION
This PR aims to improve handling of messages that cause errors in ingest. 
Specifically,

- checks that requeued nacked messages will not clog the queue and adds a short comment 
for future reference  

- adds nacking mechanism to handle failure of opening a file (e.g. nonexistent files etc)

- refactors and fixes related trigger-failure integration tests (except from one). 
The tests are deactivated for now until #321 is closed.

- Closes #230 and partially fixes #321.