### PR TITLE
Refactor/verify nack checks

### DIFF
--- a/.github/integration/setup/common/22_create_and_encrypt_large_file.sh
+++ b/.github/integration/setup/common/22_create_and_encrypt_large_file.sh
@@ -34,3 +34,9 @@ EOD
 
 crypt4gh encrypt --recipient_pk wrong_key.pub < wrongly_encrypted.raw > wrongly_encrypted.c4gh
 rm -f wrongly_encrypted.raw wrong_key.pub wrong_key.key
+
+touch test_db_file.raw
+shred -n 1 -s "$RANDOM" test_db_file.raw
+
+crypt4gh encrypt --recipient_pk c4gh.pub.pem < test_db_file.raw > test_db_file.c4gh
+rm test_db_file.raw

--- a/.github/integration/setup/s3/100_s3_storage_setup.sh
+++ b/.github/integration/setup/s3/100_s3_storage_setup.sh
@@ -15,3 +15,4 @@ s3cmd -c s3cmd.conf put empty.c4gh s3://inbox/empty.c4gh
 s3cmd -c s3cmd.conf put truncated1.c4gh s3://inbox/truncated1.c4gh
 s3cmd -c s3cmd.conf put truncated2.c4gh s3://inbox/truncated2.c4gh
 s3cmd -c s3cmd.conf put wrongly_encrypted.c4gh s3://inbox/wrongly_encrypted.c4gh
+s3cmd -c s3cmd.conf put test_db_file.c4gh s3://inbox/test_db_file.c4gh

--- a/.github/integration/setup/s3notls/99_s3_storage_setup.sh
+++ b/.github/integration/setup/s3notls/99_s3_storage_setup.sh
@@ -15,3 +15,4 @@ s3cmd -c s3cmd-notls.conf put empty.c4gh s3://inbox/empty.c4gh
 s3cmd -c s3cmd-notls.conf put truncated1.c4gh s3://inbox/truncated1.c4gh
 s3cmd -c s3cmd-notls.conf put truncated2.c4gh s3://inbox/truncated2.c4gh
 s3cmd -c s3cmd-notls.conf put wrongly_encrypted.c4gh s3://inbox/wrongly_encrypted.c4gh
+s3cmd -c s3cmd-notls.conf put test_db_file.c4gh s3://inbox/test_db_file.c4gh

--- a/.github/integration/tests/common/10_trigger_failures.sh
+++ b/.github/integration/tests/common/10_trigger_failures.sh
@@ -34,6 +34,7 @@ function check_move_to_error_queue() {
 	done
 	echo
 	echo "Message with \"""$1""\" moved to error queue."
+	echo
 }
 
 # Submit a file encrypted with the wrong key
@@ -224,6 +225,6 @@ curl --cacert certs/ca.pem  -vvv -u test:test 'https://localhost:15672/api/excha
 check_move_to_error_queue "unexpected EOF"
 
 
-# Cleanup cueues
+# Cleanup queues
 curl --cacert certs/ca.pem  -u test:test -X DELETE 'https://localhost:15672/api/queues/test/completed/contents'
 curl --cacert certs/ca.pem  -u test:test -X DELETE 'https://localhost:15672/api/queues/test/verified/contents'

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -147,8 +147,17 @@ func main() {
 						err)
 
 				}
+				// store full message info in case we want to fix the db entry and retry
+				infoErrorMessage := broker.InfoError{
+					Error:           "Getheader failed",
+					Reason:          err.Error(),
+					OriginalMessage: message,
+				}
+
+				body, _ := json.Marshal(infoErrorMessage)
+
 				// Send the message to an error queue so it can be analyzed.
-				if e := mq.SendMessage(delivered.CorrelationId, conf.Broker.Exchange, conf.Broker.RoutingError, conf.Broker.Durable, delivered.Body); e != nil {
+				if e := mq.SendMessage(delivered.CorrelationId, conf.Broker.Exchange, conf.Broker.RoutingError, conf.Broker.Durable, body); e != nil {
 					log.Errorf("Failed to publish getheader error message "+
 						"(corr-id: %s, user: %s, filepath: %s, fileid: %d, archivepath: %s, encryptedchecksums: %v, reverify: %t, reason: %v)",
 						delivered.CorrelationId,

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -216,12 +216,13 @@ func main() {
 					err)
 
 				// Send the message to an error queue so it can be analyzed.
-				fileError := broker.FileError{
-					User:     message.User,
-					FilePath: message.FilePath,
-					Reason:   err.Error(),
+				infoErrorMessage := broker.InfoError{
+					Error:           "Failed to open archived file",
+					Reason:          err.Error(),
+					OriginalMessage: message,
 				}
-				body, _ := json.Marshal(fileError)
+
+				body, _ := json.Marshal(infoErrorMessage)
 				if e := mq.SendMessage(delivered.CorrelationId, conf.Broker.Exchange, conf.Broker.RoutingError, conf.Broker.Durable, body); e != nil {
 
 					log.Errorf("Failed to publish file open error message "+

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -177,7 +177,7 @@ func main() {
 			file.Size, err = backend.GetFileSize(message.ArchivePath)
 
 			if err != nil {
-				log.Errorf("Failed to get archvied file size "+
+				log.Errorf("Failed to get archived file size "+
 					"(corr-id: %s, user: %s, filepath: %s, fileid: %d, archivepath: %s, encryptedchecksums: %v, reverify: %t, reason: %v)",
 					delivered.CorrelationId,
 					message.User,
@@ -205,7 +205,7 @@ func main() {
 
 			f, err := backend.NewFileReader(message.ArchivePath)
 			if err != nil {
-				log.Errorf("Failed to open archvied file "+
+				log.Errorf("Failed to open archived file "+
 					"(corr-id: %s, user: %s, filepath: %s, archivepath: %s, encryptedchecksums: %v, reverify: %t, reason: %v)",
 					delivered.CorrelationId,
 					message.User,

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -71,6 +71,13 @@ type FileError struct {
 	Reason   string `json:"reason"`
 }
 
+// InfoError struct for sending detailed error messages to analysis.
+type InfoError struct {
+	Error           string      `json:"error"`
+	Reason          string      `json:"reason"`
+	OriginalMessage interface{} `json:"original-message"`
+}
+
 // NewMQ creates a new Broker that can communicate with a backend
 // amqp server.
 func NewMQ(config MQConf) (*AMQPBroker, error) {


### PR DESCRIPTION
This PR aims to improve handling of messages that cause errors in verify. 

- checked nacking mechanisms that are in place

- adds info to messages sent to the error queue so that their analysis is easier

- adds integration test for nacking of msgs that trigger "Getheader failure" (deactivated for now)

Closes #344