### PR TITLE
Refactor error queue messages

### DIFF
--- a/.github/integration/setup/common/20_tools.sh
+++ b/.github/integration/setup/common/20_tools.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 pip3 install crypt4gh
+sudo apt-get install -y expect

--- a/.github/integration/tests/common/10_trigger_failures.sh
+++ b/.github/integration/tests/common/10_trigger_failures.sh
@@ -24,10 +24,12 @@ function check_move_to_error_queue() {
 		RETRY_TIMES=$((RETRY_TIMES + 1))
 		if [ $RETRY_TIMES -eq 61 ]; then
 			echo "::error::Time out while waiting for msg to move to error queue, logs:"
-			echo
-			echo ingest
-			echo
-			docker logs --since="$now" ingest
+			for k in ingest verify; do
+				echo
+				echo "$k"
+				echo
+				docker logs --since="$now" "$k"
+			done
 			exit 1
 		fi
 		sleep 2

--- a/.github/integration/tests/common/10_trigger_failures.sh
+++ b/.github/integration/tests/common/10_trigger_failures.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
+if [ "$STORAGETYPE" = s3notls ]; then
+    exit 0
+fi
+
 cd dev_utils || exit 1
-exit 0
+
 #
 # Submit some messages that will trigger various failures. Do this
 # before the "real" work to verify that these failures are not top of
@@ -109,7 +113,11 @@ curl --cacert certs/ca.pem  -vvv -u test:test 'https://localhost:15672/api/excha
 
 # Verify that message is moved to the error queue (takes a few mins).
 
-check_move_to_error_queue "NoSuchKey: The specified key does not exist."
+if [ "$STORAGETYPE" = posix ]; then
+	check_move_to_error_queue "no such file or directory"
+else
+	check_move_to_error_queue "NoSuchKey: The specified key does not exist."
+fi
 
 : <<'END_COMMENT'
 # (currently not implemented)

--- a/.github/integration/tests/common/8_bad_messages.sh
+++ b/.github/integration/tests/common/8_bad_messages.sh
@@ -6,10 +6,39 @@
 # queue and handled again and again.
 #
 
-# disable for now since this doesn't work properly
+# disable for now
 exit 0
 
-for routingkey in files archived verified completed accessionIDs; do
+function check_move_to_error_queue() {
+	now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	echo "$now"
+	RETRY_TIMES=0
+	echo
+	echo "Waiting for msg containing \"""$1""\" to move to error queue."
+	until curl --cacert dev_utils/certs/ca.pem  -u test:test 'https://localhost:15672/api/queues/test/error/get' \
+		-H 'Content-Type: application/json;charset=UTF-8' \
+		-d '{"count":1,"ackmode":"ack_requeue_false","encoding":"auto","truncate":50000}' 2>&1 | grep -q "$1"; do
+		printf '%s' "."
+		RETRY_TIMES=$((RETRY_TIMES + 1))
+		if [ $RETRY_TIMES -eq 30 ]; then
+			echo "::error::Time out while waiting for msg to move to error queue, logs:"
+			for k in intercept ingest verify sync finalize mapper; do
+				echo
+				echo "$k"
+				echo
+				docker logs --since="$now" "$k"
+			done
+			exit 1
+		fi
+		sleep 2
+	done
+	echo
+	echo "Message with \"""$1""\" moved to error queue."
+	echo
+}
+
+#routingkey files requires fixing of #323 first
+for routingkey in ingest archived accessionIDs backup mappings; do
 	curl --cacert dev_utils/certs/ca.pem -vvv -u test:test 'https://localhost:15672/api/exchanges/test/sda/publish' \
 		-H 'Content-Type: application/json;charset=UTF-8' \
 		--data-binary '{
@@ -28,7 +57,10 @@ for routingkey in files archived verified completed accessionIDs; do
 					}'
 done
 
-for routingkey in files archived verified completed accessionIDs; do
+check_move_to_error_queue "I give you bad json"
+
+#routingkey files requires fixing of #323 first
+for routingkey in ingest archived accessionIDs backup mappings; do
 	curl --cacert dev_utils/certs/ca.pem -vvv -u test:test 'https://localhost:15672/api/exchanges/test/sda/publish' \
 		-H 'Content-Type: application/json;charset=UTF-8' \
 		--data-binary '{
@@ -45,3 +77,8 @@ for routingkey in files archived verified completed accessionIDs; do
 						"payload":"{ \"json\":\"yes, but not sda\" }"
 					}'
 done
+
+check_move_to_error_queue "yes, but not sda"
+
+# Cleanup queues
+curl --cacert dev_utils/certs/ca.pem  -u test:test -X DELETE 'https://localhost:15672/api/queues/test/error/contents'

--- a/.github/integration/tests/common/8_bad_messages.sh
+++ b/.github/integration/tests/common/8_bad_messages.sh
@@ -5,9 +5,11 @@
 # before the "real" work to verify that these failures are not top of
 # queue and handled again and again.
 #
+if [ "$STORAGETYPE" = s3notls ]; then
+    exit 0
+fi
 
-# disable for now
-exit 0
+cd dev_utils || exit 1
 
 function check_move_to_error_queue() {
 	now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -15,7 +17,7 @@ function check_move_to_error_queue() {
 	RETRY_TIMES=0
 	echo
 	echo "Waiting for msg containing \"""$1""\" to move to error queue."
-	until curl --cacert dev_utils/certs/ca.pem  -u test:test 'https://localhost:15672/api/queues/test/error/get' \
+	until curl --cacert certs/ca.pem  -u test:test 'https://localhost:15672/api/queues/test/error/get' \
 		-H 'Content-Type: application/json;charset=UTF-8' \
 		-d '{"count":1,"ackmode":"ack_requeue_false","encoding":"auto","truncate":50000}' 2>&1 | grep -q "$1"; do
 		printf '%s' "."
@@ -39,7 +41,7 @@ function check_move_to_error_queue() {
 
 #routingkey files requires fixing of #323 first
 for routingkey in ingest archived accessionIDs backup mappings; do
-	curl --cacert dev_utils/certs/ca.pem -vvv -u test:test 'https://localhost:15672/api/exchanges/test/sda/publish' \
+	curl --cacert certs/ca.pem -vvv -u test:test 'https://localhost:15672/api/exchanges/test/sda/publish' \
 		-H 'Content-Type: application/json;charset=UTF-8' \
 		--data-binary '{
 						"vhost":"test",
@@ -61,7 +63,7 @@ check_move_to_error_queue "I give you bad json"
 
 #routingkey files requires fixing of #323 first
 for routingkey in ingest archived accessionIDs backup mappings; do
-	curl --cacert dev_utils/certs/ca.pem -vvv -u test:test 'https://localhost:15672/api/exchanges/test/sda/publish' \
+	curl --cacert certs/ca.pem -vvv -u test:test 'https://localhost:15672/api/exchanges/test/sda/publish' \
 		-H 'Content-Type: application/json;charset=UTF-8' \
 		--data-binary '{
 						"vhost":"test",
@@ -81,4 +83,4 @@ done
 check_move_to_error_queue "yes, but not sda"
 
 # Cleanup queues
-curl --cacert dev_utils/certs/ca.pem  -u test:test -X DELETE 'https://localhost:15672/api/queues/test/error/contents'
+curl --cacert certs/ca.pem  -u test:test -X DELETE 'https://localhost:15672/api/queues/test/error/contents'

--- a/.github/integration/tests/common/8_bad_messages.sh
+++ b/.github/integration/tests/common/8_bad_messages.sh
@@ -57,9 +57,10 @@ for routingkey in ingest archived accessionIDs backup mappings; do
 						"payload":"{
 						I give you bad json!}"
 					}'
-done
 
 check_move_to_error_queue "I give you bad json"
+
+done
 
 #routingkey files requires fixing of #323 first
 for routingkey in ingest archived accessionIDs backup mappings; do
@@ -78,9 +79,10 @@ for routingkey in ingest archived accessionIDs backup mappings; do
 						"payload_encoding":"string",
 						"payload":"{ \"json\":\"yes, but not sda\" }"
 					}'
-done
 
 check_move_to_error_queue "yes, but not sda"
+
+done
 
 # Cleanup queues
 curl --cacert certs/ca.pem  -u test:test -X DELETE 'https://localhost:15672/api/queues/test/error/contents'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run setup scripts
-        run: 'set -e;              
+        run: 'set -e;
               ls -1 .github/integration/setup/{common,${{ matrix.storagetype }}}/*.sh 2>/dev/null | sort -t/ -k5 -n | while read -r runscript; do
                  echo "Executing setup script $runscript";
                  bash -x "$runscript";

--- a/cmd/ingest/ingest.go
+++ b/cmd/ingest/ingest.go
@@ -142,10 +142,10 @@ func main() {
 						e)
 				}
 				// Send the message to an error queue so it can be analyzed.
-				fileError := broker.FileError{
-					User:     message.User,
-					FilePath: message.Filepath,
-					Reason:   err.Error(),
+				fileError := broker.InfoError{
+					Error:           "Failed to open file to ingest",
+					Reason:          err.Error(),
+					OriginalMessage: message,
 				}
 				body, _ := json.Marshal(fileError)
 				if e := mq.SendMessage(delivered.CorrelationId, conf.Broker.Exchange, conf.Broker.RoutingError, conf.Broker.Durable, body); e != nil {
@@ -179,10 +179,10 @@ func main() {
 						e)
 				}
 				// Send the message to an error queue so it can be analyzed.
-				fileError := broker.FileError{
-					User:     message.User,
-					FilePath: message.Filepath,
-					Reason:   err.Error(),
+				fileError := broker.InfoError{
+					Error:           "Failed to get file size of file to ingest",
+					Reason:          err.Error(),
+					OriginalMessage: message,
 				}
 				body, _ := json.Marshal(fileError)
 				if e := mq.SendMessage(delivered.CorrelationId, conf.Broker.Exchange, conf.Broker.RoutingError, conf.Broker.Durable, body); e != nil {
@@ -299,10 +299,10 @@ func main() {
 						}
 
 						// Send the message to an error queue so it can be analyzed.
-						fileError := broker.FileError{
-							User:     message.User,
-							FilePath: message.Filepath,
-							Reason:   err.Error(),
+						fileError := broker.InfoError{
+							Error:           "Trying to decrypt start of file failed",
+							Reason:          err.Error(),
+							OriginalMessage: message,
 						}
 						body, _ := json.Marshal(fileError)
 						if e := mq.SendMessage(delivered.CorrelationId, conf.Broker.Exchange, conf.Broker.RoutingError, conf.Broker.Durable, body); e != nil {

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -57,16 +57,9 @@ type MQConf struct {
 	SchemasPath        string
 }
 
-// FileError struct for sending file error messages to analysis
-type FileError struct {
-	User     string `json:"user"`
-	FilePath string `json:"filepath"`
-	Reason   string `json:"reason"`
-}
-
 // InfoError struct for sending detailed error messages to analysis.
-// The empty interface allows for sending dynamical json msgs but also broken json msgs as strings.
-// It is ok as long as we do not need to parse the msg, which we don't.
+// The empty interface allows for appending various json msgs but also broken json msgs as strings.
+// It is ok as long as we do not need to access fields in the msg, which we don't.
 type InfoError struct {
 	Error           string      `json:"error"`
 	Reason          string      `json:"reason"`

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -57,13 +57,6 @@ type MQConf struct {
 	SchemasPath        string
 }
 
-// jsonError struct for sending broken messages to analysis
-type jsonError struct {
-	Error           string `json:"error"`
-	Reason          string `json:"reason"`
-	OriginalMessage []byte `json:"original-message"`
-}
-
 // FileError struct for sending file error messages to analysis
 type FileError struct {
 	User     string `json:"user"`
@@ -72,6 +65,8 @@ type FileError struct {
 }
 
 // InfoError struct for sending detailed error messages to analysis.
+// The empty interface allows for sending dynamical json msgs but also broken json msgs as strings.
+// It is ok as long as we do not need to parse the msg, which we don't.
 type InfoError struct {
 	Error           string      `json:"error"`
 	Reason          string      `json:"reason"`
@@ -252,10 +247,10 @@ func (broker *AMQPBroker) ConnectionWatcher() *amqp.Error {
 // SendJSONError sends message on JSON error
 func (broker *AMQPBroker) SendJSONError(delivered *amqp.Delivery, originalBody []byte, reason string, conf MQConf) error {
 
-	jsonErrorMessage := jsonError{
+	jsonErrorMessage := InfoError{
 		Error:           "Validation of JSON message failed",
 		Reason:          fmt.Sprintf("%v", reason),
-		OriginalMessage: originalBody,
+		OriginalMessage: string(originalBody),
 	}
 
 	body, _ := json.Marshal(jsonErrorMessage)


### PR DESCRIPTION
This PR replaces all structs that were used to send messages to the error queue with one standard structure that is suitable for appending different kinds of info. In addition,
- sets output of json related errors to human readable
- fixes integration tests related to broken json errors (deactivated for now)

The logic behind using an empty interface as a holder for appended messages is to:
- allow for dynamic json so that when the file moves through the pipeline and relevant info accumulates, the exact message that triggered the error can be sent to the error queue
- handle different types, e.g. for broken or non json related errors where unmarshalling is not possible
- preserve the json format of the original message so that messages in the error queue are easy to parse, if needed

Closes #355