### PR TITLE
fix godocs github actions when no changes detected #none

### DIFF
--- a/.github/workflows/create_docs.yaml
+++ b/.github/workflows/create_docs.yaml
@@ -37,6 +37,11 @@ jobs:
             cd "${GITHUB_WORKSPACE}/gh-pages"
             git config user.name github-actions
             git config user.email github-actions@github.com
-            git add .
-            git commit -m "Generated documentation"
-            git push origin gh-pages
+            if output=$(git status --untracked-files=no --porcelain) && [ -z "$output" ]; then
+              echo "Working directory clean. No changes detected, documentation up to date."
+            else 
+              echo "Changes detected"
+              git add .
+              git commit -m "Generated documentation"
+              git push origin gh-pages
+            fi


### PR DESCRIPTION
github-pages update fails if there are no updates to the documentation, this aims to fix that.