### PR TITLE
Bugfix/intercept handle faulty messages

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -238,10 +238,10 @@ func (broker *AMQPBroker) ConnectionWatcher() *amqp.Error {
 }
 
 // SendJSONError sends message on JSON error
-func (broker *AMQPBroker) SendJSONError(delivered *amqp.Delivery, originalBody []byte, reason string, conf MQConf) error {
+func (broker *AMQPBroker) SendJSONError(delivered *amqp.Delivery, originalBody []byte, conf MQConf, reason, errorMsg string) error {
 
 	jsonErrorMessage := InfoError{
-		Error:           "Validation of JSON message failed",
+		Error:           errorMsg,
 		Reason:          fmt.Sprintf("%v", reason),
 		OriginalMessage: string(originalBody),
 	}
@@ -275,7 +275,7 @@ func (broker *AMQPBroker) ValidateJSON(delivered *amqp.Delivery,
 				e)
 		}
 		// Send the message to an error queue so it can be analyzed.
-		if e := broker.SendJSONError(delivered, body, err.Error(), broker.Conf); e != nil {
+		if e := broker.SendJSONError(delivered, body, broker.Conf, err.Error(), "Validation of JSON message failed"); e != nil {
 			log.Errorf("Failed to publish JSON decode error message "+
 				"(corr-id: %s, error: %v)",
 				delivered.CorrelationId,
@@ -306,7 +306,7 @@ func (broker *AMQPBroker) ValidateJSON(delivered *amqp.Delivery,
 				e)
 		}
 		// Send the message to an error queue so it can be analyzed.
-		if e := broker.SendJSONError(delivered, body, errorString, broker.Conf); e != nil {
+		if e := broker.SendJSONError(delivered, body, broker.Conf, errorString, "Validation of JSON message failed"); e != nil {
 			log.Errorf("Failed to publish JSON validity error message "+
 				"(corr-id: %s, error: %v)",
 				delivered.CorrelationId,

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -378,10 +378,10 @@ func TestSendJSONError(t *testing.T) {
 
 	message := testMsg{Test: "some json"}
 	messageText, _ := json.Marshal(message)
-	err = b.SendJSONError(&msg, messageText, "some reason", b.Conf)
+	err = b.SendJSONError(&msg, messageText, b.Conf, "some reason", "some error msg")
 	assert.Nil(t, err, "SendJSONError failed unexpectedly (json payload)")
 
 	messageText = []byte("some string")
-	err = b.SendJSONError(&msg, messageText, "some reason", b.Conf)
+	err = b.SendJSONError(&msg, messageText, b.Conf, "some reason", "some error msg")
 	assert.Nil(t, err, "SendJSONError failed unexpectedly (string payload)")
 }


### PR DESCRIPTION
This PR fixes how intercept handles cases of incoming bad messages, e.g. non-json, of wrong type or schema etc., by permanently moving them to the error queue.

- slightly modified the `SendJSONError` in `broker.go` to extend its usage scope
- added related integration tests in `08_bad_messages.sh`

Closes #323