### PR TITLE
Fix integration test folder

### DIFF
--- a/.github/integration/tests/posix/50_check_files.sh
+++ b/.github/integration/tests/posix/50_check_files.sh
@@ -8,25 +8,31 @@ echo "Checking archive files in backup"
 
 # Earlier tests verify that the file is in the database correctly
 
-accessids=$(docker run --rm --name client --network dev_utils_default -v ./certs:/certs \
+accessids=$(docker run --rm --name client --network dev_utils_default -v /home/runner/work/sda-pipeline/sda-pipeline/dev_utils/certs:/certs \
 	-e PGSSLCERT=certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
 	neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
 	-t -A -c "SELECT stable_id FROM local_ega.files where status='READY';")
 
+if $accessids; then
+	echo "Failed to get accession ids"
+	exit 1
+fi
+
+
 for aid in $accessids; do
 	echo "Checking accesssionid $aid"
 
-	apath=$(docker run --rm --name client --network dev_utils_default -v ./certs:/certs \
+	apath=$(docker run --rm --name client --network dev_utils_default -v /home/runner/work/sda-pipeline/sda-pipeline/dev_utils/certs:/certs \
 		-e PGSSLCERT=certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
 		neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
 		-t -A -c "SELECT archive_path FROM local_ega.files where stable_id='$aid';")
 
-	acheck=$(docker run --rm --name client --network dev_utils_default -v ./certs:/certs \
+	acheck=$(docker run --rm --name client --network dev_utils_default -v /home/runner/work/sda-pipeline/sda-pipeline/dev_utils/certs:/certs \
 		-e PGSSLCERT=certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
 		neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
 		-t -A -c "SELECT archive_file_checksum FROM local_ega.files where stable_id='$aid';")
 
-	achecktype=$(docker run --rm --name client --network dev_utils_default -v ./certs:/certs \
+	achecktype=$(docker run --rm --name client --network dev_utils_default -v /home/runner/work/sda-pipeline/sda-pipeline/dev_utils/certs:/certs \
 		-e PGSSLCERT=certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
 		neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
 		-t -A -c "SELECT archive_file_checksum_type FROM local_ega.files where stable_id='$aid';")

--- a/.github/integration/tests/posixheader/50_check_files.sh
+++ b/.github/integration/tests/posixheader/50_check_files.sh
@@ -8,30 +8,35 @@ echo "Checking archive files in backup"
 
 # Earlier tests verify that the file is in the database correctly
 
-accessids=$(docker run --rm --name client --network dev_utils_default -v ./certs:/certs \
+accessids=$(docker run --rm --name client --network dev_utils_default -v /home/runner/work/sda-pipeline/sda-pipeline/dev_utils/certs:/certs \
 	-e PGSSLCERT=certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
 	neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
 	-t -A -c "SELECT stable_id FROM local_ega.files where status='READY';")
 
+if $accessids; then
+	echo "Failed to get accession ids"
+	exit 1
+fi
+
 for aid in $accessids; do
 	echo "Checking accesssionid $aid"
 
-	apath=$(docker run --rm --name client --network dev_utils_default -v ./certs:/certs \
+	apath=$(docker run --rm --name client --network dev_utils_default -v /home/runner/work/sda-pipeline/sda-pipeline/dev_utils/certs:/certs \
 		-e PGSSLCERT=certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
 		neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
 		-t -A -c "SELECT archive_path FROM local_ega.files where stable_id='$aid';")
 
-	acheck=$(docker run --rm --name client --network dev_utils_default -v ./certs:/certs \
+	acheck=$(docker run --rm --name client --network dev_utils_default -v /home/runner/work/sda-pipeline/sda-pipeline/dev_utils/certs:/certs \
 		-e PGSSLCERT=certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
 		neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
 		-t -A -c "SELECT archive_file_checksum FROM local_ega.files where stable_id='$aid';")
 
-	achecktype=$(docker run --rm --name client --network dev_utils_default -v ./certs:/certs \
+	achecktype=$(docker run --rm --name client --network dev_utils_default -v /home/runner/work/sda-pipeline/sda-pipeline/dev_utils/certs:/certs \
 		-e PGSSLCERT=certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
 		neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
 		-t -A -c "SELECT archive_file_checksum_type FROM local_ega.files where stable_id='$aid';")
 
-	decrcheck=$(docker run --rm --name client --network dev_utils_default -v ./certs:/certs \
+	decrcheck=$(docker run --rm --name client --network dev_utils_default -v /home/runner/work/sda-pipeline/sda-pipeline/dev_utils/certs:/certs \
 		-e PGSSLCERT=certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
 		neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
 		-t -A -c "SELECT decrypted_file_checksum FROM local_ega.files where stable_id='$aid';")

--- a/.github/integration/tests/s3/50_check_files.sh
+++ b/.github/integration/tests/s3/50_check_files.sh
@@ -8,25 +8,30 @@ echo "Checking archive files in s3"
 
 # Earlier tests verify that the file is in the database correctly
 
-accessids=$(docker run --rm --name client --network dev_utils_default -v ./certs:/certs \
+accessids=$(docker run --rm --name client --network dev_utils_default -v /home/runner/work/sda-pipeline/sda-pipeline/dev_utils/certs:/certs \
 	-e PGSSLCERT=certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
 	neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
 	-t -A -c "SELECT stable_id FROM local_ega.files where status='READY';")
 
+if $accessids; then
+	echo "Failed to get accession ids"
+	exit 1
+fi
+
 for aid in $accessids; do
 	echo "Checking accesssionid $aid"
 
-	apath=$(docker run --rm --name client --network dev_utils_default -v ./certs:/certs \
+	apath=$(docker run --rm --name client --network dev_utils_default -v /home/runner/work/sda-pipeline/sda-pipeline/dev_utils/certs:/certs \
 		-e PGSSLCERT=certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
 		neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
 		-t -A -c "SELECT archive_path FROM local_ega.files where stable_id='$aid';")
 
-	acheck=$(docker run --rm --name client --network dev_utils_default -v ./certs:/certs \
+	acheck=$(docker run --rm --name client --network dev_utils_default -v /home/runner/work/sda-pipeline/sda-pipeline/dev_utils/certs:/certs \
 		-e PGSSLCERT=certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
 		neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
 		-t -A -c "SELECT archive_file_checksum FROM local_ega.files where stable_id='$aid';")
 
-	achecktype=$(docker run --rm --name client --network dev_utils_default -v ./certs:/certs \
+	achecktype=$(docker run --rm --name client --network dev_utils_default -v /home/runner/work/sda-pipeline/sda-pipeline/dev_utils/certs:/certs \
 		-e PGSSLCERT=certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
 		neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
 		-t -A -c "SELECT archive_file_checksum_type FROM local_ega.files where stable_id='$aid';")

--- a/.github/integration/tests/s3header/50_check_files.sh
+++ b/.github/integration/tests/s3header/50_check_files.sh
@@ -8,30 +8,35 @@ echo "Checking archive files in s3"
 
 # Earlier tests verify that the file is in the database correctly
 
-accessids=$(docker run --rm --name client --network dev_utils_default -v ./certs:/certs \
+accessids=$(docker run --rm --name client --network dev_utils_default -v /home/runner/work/sda-pipeline/sda-pipeline/dev_utils/certs:/certs \
 	-e PGSSLCERT=certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
 	neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
 	-t -A -c "SELECT stable_id FROM local_ega.files where status='READY';")
 
+if $accessids; then
+	echo "Failed to get accession ids"
+	exit 1
+fi
+
 for aid in $accessids; do
 	echo "Checking accesssionid $aid"
 
-	apath=$(docker run --rm --name client --network dev_utils_default -v ./certs:/certs \
+	apath=$(docker run --rm --name client --network dev_utils_default -v /home/runner/work/sda-pipeline/sda-pipeline/dev_utils/certs:/certs \
 		-e PGSSLCERT=certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
 		neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
 		-t -A -c "SELECT archive_path FROM local_ega.files where stable_id='$aid';")
 
-	acheck=$(docker run --rm --name client --network dev_utils_default -v ./certs:/certs \
+	acheck=$(docker run --rm --name client --network dev_utils_default -v /home/runner/work/sda-pipeline/sda-pipeline/dev_utils/certs:/certs \
 		-e PGSSLCERT=certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
 		neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
 		-t -A -c "SELECT archive_file_checksum FROM local_ega.files where stable_id='$aid';")
 
-	achecktype=$(docker run --rm --name client --network dev_utils_default -v ./certs:/certs \
+	achecktype=$(docker run --rm --name client --network dev_utils_default -v /home/runner/work/sda-pipeline/sda-pipeline/dev_utils/certs:/certs \
 		-e PGSSLCERT=certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
 		neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
 		-t -A -c "SELECT archive_file_checksum_type FROM local_ega.files where stable_id='$aid';")
 
-	decrcheck=$(docker run --rm --name client --network dev_utils_default -v ./certs:/certs \
+	decrcheck=$(docker run --rm --name client --network dev_utils_default -v /home/runner/work/sda-pipeline/sda-pipeline/dev_utils/certs:/certs \
 		-e PGSSLCERT=certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
 		neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
 		-t -A -c "SELECT archive_file_checksum FROM local_ega.files where stable_id='$aid';")

--- a/.github/integration/tests/s3header/50_check_files.sh
+++ b/.github/integration/tests/s3header/50_check_files.sh
@@ -39,7 +39,7 @@ for aid in $accessids; do
 	decrcheck=$(docker run --rm --name client --network dev_utils_default -v /home/runner/work/sda-pipeline/sda-pipeline/dev_utils/certs:/certs \
 		-e PGSSLCERT=certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
 		neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
-		-t -A -c "SELECT archive_file_checksum FROM local_ega.files where stable_id='$aid';")
+		-t -A -c "SELECT decrypted_file_checksum FROM local_ega.files where stable_id='$aid';")
 
 	s3cmd -c s3cmd.conf get "s3://archive/$apath" "tmp/$apath"
 


### PR DESCRIPTION
This PR is a fix for the integration tests and specifically the `50_check_files.sh` file, and specifically when comparing checksums for the different types of backends. It includes:
- Add path to the certificates for all tls enabled backends
- Fail in case no accession ids are found in the integration test
- Change the db query for s3 backend

Closes: #411 