### PR TITLE
move crypt4gh to neicnordic management

### DIFF
--- a/cmd/backup/backup.go
+++ b/cmd/backup/backup.go
@@ -15,7 +15,7 @@ import (
 	"sda-pipeline/internal/database"
 	"sda-pipeline/internal/storage"
 
-	"github.com/elixir-oslo/crypt4gh/model/headers"
+	"github.com/neicnordic/crypt4gh/model/headers"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -544,7 +544,7 @@ func FormatHexHeader(hexData string, secKey [32]byte) (*headers.Header, error) {
 }
 
 // Modified struct of the Crypt4GHWriter struct which can be found here:
-// https://github.com/elixir-oslo/crypt4gh/blob/master/streaming/out.go
+// https://github.com/neicnordic/crypt4gh/blob/master/streaming/out.go
 type headerWriter struct {
 	header                               headers.Header
 	dataEncryptionParametersHeaderPacket headers.DataEncryptionParametersHeaderPacket

--- a/cmd/ingest/ingest.go
+++ b/cmd/ingest/ingest.go
@@ -16,8 +16,8 @@ import (
 	"sda-pipeline/internal/database"
 	"sda-pipeline/internal/storage"
 
-	"github.com/elixir-oslo/crypt4gh/model/headers"
-	"github.com/elixir-oslo/crypt4gh/streaming"
+	"github.com/neicnordic/crypt4gh/model/headers"
+	"github.com/neicnordic/crypt4gh/streaming"
 	"github.com/google/uuid"
 
 	log "github.com/sirupsen/logrus"

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -16,7 +16,7 @@ import (
 	"sda-pipeline/internal/database"
 	"sda-pipeline/internal/storage"
 
-	"github.com/elixir-oslo/crypt4gh/streaming"
+	"github.com/neicnordic/crypt4gh/streaming"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,11 @@ go 1.17
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/aws/aws-sdk-go v1.44.91
-	github.com/elixir-oslo/crypt4gh v1.5.1
 	github.com/google/uuid v1.3.0
 	github.com/johannesboyne/gofakes3 v0.0.0-20220627085814-c3ac35da23b2
 	github.com/lib/pq v1.10.6
 	github.com/mocktools/go-smtp-mock v1.9.0
+	github.com/neicnordic/crypt4gh v1.5.2
 	github.com/pkg/errors v0.9.1
 	github.com/rabbitmq/amqp091-go v1.4.0
 	github.com/sirupsen/logrus v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dchest/bcrypt_pbkdf v0.0.0-20150205184540-83f37f9c154a h1:saTgr5tMLFnmy/yg3qDTft4rE5DY2uJ/cCxCe3q0XTU=
 github.com/dchest/bcrypt_pbkdf v0.0.0-20150205184540-83f37f9c154a/go.mod h1:Bw9BbhOJVNR+t0jCqx2GC6zv0TGBsShs56Y3gfSCvl0=
-github.com/elixir-oslo/crypt4gh v1.5.1 h1:Mt7266OfQzieu6Mnqe0UIXSIItHYQRJa9103ukp4MVU=
-github.com/elixir-oslo/crypt4gh v1.5.1/go.mod h1:7w1beOQEJ/b3s5DH6bQT0/ArEtKPHtombCH3tsII3yc=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -161,6 +159,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mocktools/go-smtp-mock v1.9.0 h1:rfRHLMj7N3tPl5BmAGy/iX+uSr1BId4T05/KTQ7grq4=
 github.com/mocktools/go-smtp-mock v1.9.0/go.mod h1:Yg+FBG1r8q7ImrFLWYGpiHCJzBOkLFYzomSjs8m4cXc=
+github.com/neicnordic/crypt4gh v1.5.2 h1:p6xmo9Ymeb24yNvDcdv5SkUh9obFC1++iUrVJ/U/3w4=
+github.com/neicnordic/crypt4gh v1.5.2/go.mod h1:EwsS60OQgdNS7mTAM5DZNGyj296OEFAwGkYFSdBrqOA=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.0.2 h1:+jQXlF3scKIcSEKkdHzXhCTDLPFi5r1wnK6yPS+49Gw=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/elixir-oslo/crypt4gh/keys"
+	"github.com/neicnordic/crypt4gh/keys"
 	log "github.com/sirupsen/logrus"
 
 	"sda-pipeline/internal/broker"


### PR DESCRIPTION
moved from elixir-oslo/crypt4gh to neicnordic/crypt4gh - available with version 1.5.2 (https://pkg.go.dev/github.com/neicnordic/crypt4gh)