### PR TITLE
missing c4gh keys causes failed start in backup service

### DIFF
--- a/cmd/backup/backup.go
+++ b/cmd/backup/backup.go
@@ -56,14 +56,19 @@ func main() {
 		log.Fatal(err)
 	}
 
-	key, err := config.GetC4GHKey()
-	if err != nil {
-		log.Fatal(err)
-	}
+	// we don't need crypt4gh keys if copyheader disabled
+	var key *[32]byte
+	var publicKey *[32]byte
+	if config.CopyHeader() {
+		key, err = config.GetC4GHKey()
+		if err != nil {
+			log.Fatal(err)
+		}
 
-	publicKey, err := config.GetC4GHPublicKey()
-	if err != nil {
-		log.Fatal(err)
+		publicKey, err = config.GetC4GHPublicKey()
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	defer mq.Channel.Close()


### PR DESCRIPTION
- if `copyheader` is disabled, the backup service still requires keys, and it fails to start if they don't exist