### PR TITLE
Add case for backup in original location

### DIFF
--- a/.github/integration/tests/posixheader/50_check_files.sh
+++ b/.github/integration/tests/posixheader/50_check_files.sh
@@ -57,6 +57,11 @@ for aid in $accessids; do
 
 	rm -f "tmp/$apath"
 
+	apath=$(docker run --rm --name client --network dev_utils_default -v /home/runner/work/sda-pipeline/sda-pipeline/dev_utils/certs:/certs \
+		-e PGSSLCERT=certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
+		neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
+		-t -A -c "SELECT inbox_path FROM local_ega.files where stable_id='$aid';")
+
 	# Check checksum for backuped copy as well
 	docker cp "backup:/backup/$apath" tmp/
 

--- a/.github/integration/tests/s3header/50_check_files.sh
+++ b/.github/integration/tests/s3header/50_check_files.sh
@@ -56,6 +56,11 @@ for aid in $accessids; do
 
 	rm -f "tmp/$apath"
 
+	apath=$(docker run --rm --name client --network dev_utils_default -v /home/runner/work/sda-pipeline/sda-pipeline/dev_utils/certs:/certs \
+		-e PGSSLCERT=certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
+		neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
+		-t -A -c "SELECT inbox_path FROM local_ega.files where stable_id='$aid';")
+
 	# Check checksum for backuped copy as well
 	s3cmd -c s3cmd.conf get "s3://backup/$apath" "tmp/$apath"
 

--- a/cmd/backup/backup.go
+++ b/cmd/backup/backup.go
@@ -111,6 +111,7 @@ func main() {
 					"(corr-id: %s, error: %v)",
 					delivered.CorrelationId,
 					err)
+
 				continue
 			}
 
@@ -167,6 +168,7 @@ func main() {
 						message.DecryptedChecksums,
 						e)
 				}
+
 				continue
 			}
 
@@ -242,8 +244,8 @@ func main() {
 						message.DecryptedChecksums,
 						e)
 				}
-				continue
 
+				continue
 			}
 
 			file, err := archive.NewFileReader(filePath)
@@ -277,7 +279,14 @@ func main() {
 						message.DecryptedChecksums,
 						e)
 				}
+
 				continue
+			}
+
+			// If the copy header is enabled, use the actual filepath to make backup
+			// This will be used in the BigPicture backup, enabling for ingestion of the file
+			if config.CopyHeader() {
+				filePath = message.Filepath
 			}
 
 			dest, err := backupStorage.NewFileWriter(filePath)
@@ -311,6 +320,7 @@ func main() {
 						message.DecryptedChecksums,
 						e)
 				}
+
 				continue
 			}
 
@@ -452,6 +462,7 @@ func main() {
 						message.DecryptedChecksums,
 						e)
 				}
+
 				continue
 			}
 

--- a/cmd/backup/backup.md
+++ b/cmd/backup/backup.md
@@ -3,7 +3,7 @@
 Moves data to backup storage and optionally merges it with the encryption header.
 
 ## Service Description
-The backup service copies files from the archive storage to backup storage. If a public key is supplied the header will be re-encrypted and attached to the file before writing it to backup storage.
+The backup service copies files from the archive storage to backup storage. If a public key is supplied and the copyHeader option is enabled the header will be re-encrypted and attached to the file before writing it to backup storage.
 
 When running, backup reads messages from the configured RabbitMQ queue (default "backup").
 For each message, these steps are taken (if not otherwise noted, errors halts progress, the message is Nack'ed, and the service moves on to the next message):
@@ -11,7 +11,8 @@ For each message, these steps are taken (if not otherwise noted, errors halts pr
 1. The message is validated as valid JSON that matches either the "ingestion-completion" or "ingestion-accession" schema (based on configuration).
 If the message can’t be validated it is discarded with an error message in the logs.
 
-1. The file path and file size is fetched from the database.
+1. The file path and file size is fetched from the database. 
+    1. In case the service is configured to copy headers, the path is replaced by the one of the incoming message and it is the original location where the file was uploaded in the inbox.
 
 1. The file size on disk is requested from the storage system.
 


### PR DESCRIPTION
The backup service is currently copying the file as in the same location as the archive (using the archive path). For the syncing between countries in BigPicture we need to copy the file in the original location (using the inbox path). 

This PR uses the original location in case the `copyHeader` parameter is set to true.


Co-Authored-By: kostas-kou <kkoumpouras@gmail.com>