### PR TITLE
Add nack when mapping fails

### DIFF
--- a/cmd/mapper/mapper.go
+++ b/cmd/mapper/mapper.go
@@ -5,7 +5,6 @@ package main
 import (
 	"encoding/json"
 	"os"
-	"time"
 
 	"sda-pipeline/internal/broker"
 	"sda-pipeline/internal/config"
@@ -91,9 +90,6 @@ func main() {
 					mappings.DatasetID,
 					mappings.AccessionIDs,
 					err)
-
-				// Before nacking the message, sleep in order to wait for the db to recover
-				time.Sleep(5 * time.Second)
 
 				// Nack message so the server gets notified that something is wrong but don't requeue the message
 				if e := delivered.Nack(false, true); e != nil {

--- a/cmd/mapper/mapper.go
+++ b/cmd/mapper/mapper.go
@@ -91,9 +91,9 @@ func main() {
 					mappings.AccessionIDs,
 					err)
 
-				// Nack message so the server gets notified that something is wrong but don't requeue the message
+				// Nack message so the server gets notified that something is wrong and requeue the message
 				if e := delivered.Nack(false, true); e != nil {
-					log.Errorf("Failed to nack following getheader error message "+
+					log.Errorf("Failed to nack message on mapping files to dataset) "+
 						"(corr-id: %s, "+
 						"datasetid: %s, "+
 						"accessionid: %s, "+

--- a/cmd/mapper/mapper.go
+++ b/cmd/mapper/mapper.go
@@ -5,6 +5,7 @@ package main
 import (
 	"encoding/json"
 	"os"
+	"time"
 
 	"sda-pipeline/internal/broker"
 	"sda-pipeline/internal/config"
@@ -53,28 +54,28 @@ func main() {
 		if err != nil {
 			log.Fatalf("Failed to get message from mq (error: %v)", err)
 		}
-		for d := range messages {
-			log.Debugf("received a message: %s", d.Body)
-			err := mq.ValidateJSON(&d, "dataset-mapping", d.Body, &mappings)
+		for delivered := range messages {
+			log.Debugf("received a message: %s", delivered.Body)
+			err := mq.ValidateJSON(&delivered, "dataset-mapping", delivered.Body, &mappings)
 			if err != nil {
 				log.Errorf("Failed to validate message for work "+
 					"(corr-id: %s, "+
 					"message: %s, "+
 					"error: %v)",
-					d.CorrelationId,
-					d.Body,
+					delivered.CorrelationId,
+					delivered.Body,
 					err)
 
 				continue
 			}
 
-			if err := json.Unmarshal(d.Body, &mappings); err != nil {
+			if err := json.Unmarshal(delivered.Body, &mappings); err != nil {
 				log.Errorf("Failed to unmarshal message for work "+
 					"(corr-id: %s, "+
 					"message: %s, "+
 					"error: %v)",
-					d.CorrelationId,
-					d.Body,
+					delivered.CorrelationId,
+					delivered.Body,
 					err)
 
 				continue
@@ -86,33 +87,50 @@ func main() {
 					"datasetid: %s, "+
 					"accessionids: %v, "+
 					"error: %v)",
-					d.CorrelationId,
+					delivered.CorrelationId,
 					mappings.DatasetID,
 					mappings.AccessionIDs,
 					err)
+
+				// Before nacking the message, sleep in order to wait for the db to recover
+				time.Sleep(5 * time.Second)
+
+				// Nack message so the server gets notified that something is wrong but don't requeue the message
+				if e := delivered.Nack(false, true); e != nil {
+					log.Errorf("Failed to nack following getheader error message "+
+						"(corr-id: %s, "+
+						"datasetid: %s, "+
+						"accessionid: %s, "+
+						"reason: %v)",
+						delivered.CorrelationId,
+						mappings.DatasetID,
+						mappings.AccessionIDs,
+						e)
+				}
+
+				continue
 			}
 
-			for _, aId := range mappings.AccessionIDs {
+			for _, aID := range mappings.AccessionIDs {
 				log.Infof("Mapped file to dataset "+
 					"(corr-id: %s, "+
 					"datasetid: %s, "+
 					"accessionid: %s)",
-					d.CorrelationId,
+					delivered.CorrelationId,
 					mappings.DatasetID,
-					aId)
+					aID)
 			}
 
-			if err := d.Ack(false); err != nil {
+			if err := delivered.Ack(false); err != nil {
 				log.Errorf("Failed to ack message for work "+
 					"(corr-id: %s, "+
 					"datasetid: %s, "+
 					"accessionids: %v, "+
 					"error: %v)",
-					d.CorrelationId,
+					delivered.CorrelationId,
 					mappings.DatasetID,
 					mappings.AccessionIDs,
 					err)
-
 			}
 		}
 	}()

--- a/cmd/mapper/mapper.md
+++ b/cmd/mapper/mapper.md
@@ -3,15 +3,16 @@
 The mapper service registers mapping of accessionIDs (stable ids for files) to datasetIDs.
 
 ## Service Description
+
 The mapper service maps file accessionIDs to datasetIDs.
 
 When running, mapper reads messages from the configured RabbitMQ queue (default: "mappings").
 For each message, these steps are taken (if not otherwise noted, errors halt progress and the service moves on to the next message):
 
-1.  The message is validated as valid JSON that matches the "dataset-mapping" schema (defined in sda-common).
+1. The message is validated as valid JSON that matches the "dataset-mapping" schema (defined in sda-common).
 If the message can’t be validated it is discarded with an error message in the logs.
 
 1. AccessionIDs from the message are mapped to a datasetID (also in the message) in the database.
-On error the service sleeps for 5 minutes to allow for database recovery, the message is Nacked and then re-queued and an error message is written to the logs.
+On error the service sleeps for up to 5 minutes to allow for database recovery, after 5 minutes the message is Nacked, re-queued and an error message is written to the logs.
 
 1. The RabbitMQ message is Ack'ed.

--- a/cmd/mapper/mapper.md
+++ b/cmd/mapper/mapper.md
@@ -12,6 +12,6 @@ For each message, these steps are taken (if not otherwise noted, errors halt pro
 If the message can’t be validated it is discarded with an error message in the logs.
 
 1. AccessionIDs from the message are mapped to a datasetID (also in the message) in the database.
-On failure an error message is written to the logs, but processing is not halted.
+On error the service sleeps for 5 minutes to allow for database recovery, the message is Nacked and then re-queued and an error message is written to the logs.
 
 1. The RabbitMQ message is Ack'ed.

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -146,7 +146,7 @@ func main() {
 						message.ArchivePath,
 						message.EncryptedChecksums,
 						message.ReVerify,
-						err)
+						e)
 
 				}
 				// store full message info in case we want to fix the db entry and retry

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -409,7 +409,7 @@ func (dbs *SQLdb) mapFilesToDataset(datasetID string, accessionIDs []string) err
 		}
 		_, err = transaction.Exec(mapping, fileID, datasetID)
 		if err != nil {
-			log.Errorf("something went wrong with the DB query: %s", err)
+			log.Errorf("something went wrong with the DB transaction: %s", err)
 			if e := transaction.Rollback(); e != nil {
 				log.Errorf("failed to rollback the transaction: %s", e)
 			}

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -56,7 +56,7 @@ type FileInfo struct {
 }
 
 // dbRetryTimes is the number of times to retry the same function if it fails
-var dbRetryTimes = 8
+var dbRetryTimes = 5
 
 // dbReconnectTimeout is how long to try to re-establish a connection to the database
 var dbReconnectTimeout = 5 * time.Minute
@@ -376,14 +376,17 @@ func (dbs *SQLdb) markReady(accessionID, user, filepath, checksum string) error 
 // MapFilesToDataset maps a set of files to a dataset in the database
 func (dbs *SQLdb) MapFilesToDataset(datasetID string, accessionIDs []string) error {
 	var (
-		err   error = nil
-		count int   = 0
+		err   error
+		count int
 	)
 
+	// 0, 3, 9, 27, 81, 243 seconds between each retry event.
 	for count == 0 || (err != nil && count < dbRetryTimes) {
+		time.Sleep(time.Duration(count*3) * time.Second)
 		err = dbs.mapFilesToDataset(datasetID, accessionIDs)
 		count++
 	}
+
 	return err
 }
 


### PR DESCRIPTION
The PR fixes the bug with the mapper, which was acknowledging the message even in case of failure. The fix is focused on the sync functionality for the BigPicture, where the messages are all arriving in the same time to the destination, therefore the mapper might receive the message before the file has been ingested. Therefore, in case of failure, the mapper sleeps for up to 5 minutes, to give time to the database to recover or for the file to get ingested.

(Also, includes a couple of spelling mistakes in verify and db)