### PR TITLE
Add nack when finalize fails

### DIFF
--- a/cmd/finalize/finalize.go
+++ b/cmd/finalize/finalize.go
@@ -156,7 +156,7 @@ func main() {
 					message.DecryptedChecksums,
 					err)
 
-				// Nack message and requeue so the server gets notified that something is wrong. Do not requeue.
+				// Nack message so the server gets notified that something is wrong and requeue the message
 				if e := delivered.Nack(false, true); e != nil {
 					log.Errorf("Failed to NAck because of MarkReady failed "+
 						"(corr-id: %s, "+

--- a/cmd/finalize/finalize.md
+++ b/cmd/finalize/finalize.md
@@ -16,7 +16,7 @@ If the message can’t be validated it is discarded with an error message in the
 If the validation fails, an error message is written to the logs.
 
 1. The file accession ID in the message is marked as "ready" in the database.
-If this fails an error message is written to the logs, the initial message is Nack'ed, and an error message is written to the RabbitMQ error queue.
+On error the service sleeps for up to 5 minutes to allow for database recovery, after 5 minutes the message is Nacked, re-queued and an error message is written to the logs.
 
 1. The complete message is sent to RabbitMQ. On error, a message is written to the logs.
 

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -347,13 +347,10 @@ func (dbs *SQLdb) setArchived(file FileInfo, id int64) error {
 // MarkReady marks the file as "READY"
 func (dbs *SQLdb) MarkReady(accessionID, user, filepath, checksum string) error {
 
-	var (
-		err   error = nil
-		count int   = 0
-	)
+	var err error
 
 	// 3, 9, 27, 81, 243 seconds between each retry event.
-	for count = 1; count <= dbRetryTimes; count++ {
+	for count := 1; count <= dbRetryTimes; count++ {
 		err = dbs.markReady(accessionID, user, filepath, checksum)
 		if err == nil {
 			break
@@ -383,13 +380,11 @@ func (dbs *SQLdb) markReady(accessionID, user, filepath, checksum string) error 
 
 // MapFilesToDataset maps a set of files to a dataset in the database
 func (dbs *SQLdb) MapFilesToDataset(datasetID string, accessionIDs []string) error {
-	var (
-		err   error
-		count int
-	)
+
+	var err error
 
 	// 3, 9, 27, 81, 243 seconds between each retry event.
-	for count = 1; count <= dbRetryTimes; count++ {
+	for count := 1; count <= dbRetryTimes; count++ {
 		err = dbs.mapFilesToDataset(datasetID, accessionIDs)
 		if err == nil {
 			break

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -38,7 +38,7 @@ const testConnInfo = "host=localhost port=42 user=user password=password dbname=
 func TestMain(m *testing.M) {
 	// Set up our helper doing panic instead of os.exit
 	logFatalf = testLogFatalf
-	dbRetryTimes = 0
+	dbRetryTimes = 1
 	dbReconnectTimeout = 200 * time.Millisecond
 	dbReconnectSleep = time.Millisecond
 	code := m.Run()


### PR DESCRIPTION
This PR is similar to #487 and it fixes the same issue for finalize.
The fix is focused on the sync functionality for the BigPicture, where the messages are all arriving in the same time to the destination, therefore the finalize service might receive the message before the file has been ingested. Therefore, in case of failure, the finalize sleeps for up to 5 minutes, to give time to the database to recover or for the file to get ingested.

