### PR TITLE
Feature/cancel messages

### DIFF
--- a/.github/integration/setup/cancel/100_s3_storage_setup.sh
+++ b/.github/integration/setup/cancel/100_s3_storage_setup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+pip3 install s3cmd
+
+cd dev_utils || exit 1
+
+# Make buckets if they don't exist already
+s3cmd -c s3cmd.conf mb s3://inbox || true
+s3cmd -c s3cmd.conf mb s3://archive || true
+
+# Upload test file
+s3cmd -c s3cmd.conf put dummy_data.c4gh s3://inbox/dummy_data.c4gh
+s3cmd -c s3cmd.conf put largefile.c4gh s3://inbox/largefile.c4gh
+s3cmd -c s3cmd.conf put empty.c4gh s3://inbox/empty.c4gh
+s3cmd -c s3cmd.conf put truncated1.c4gh s3://inbox/truncated1.c4gh
+s3cmd -c s3cmd.conf put truncated2.c4gh s3://inbox/truncated2.c4gh
+s3cmd -c s3cmd.conf put wrongly_encrypted.c4gh s3://inbox/wrongly_encrypted.c4gh
+s3cmd -c s3cmd.conf put test_db_file.c4gh s3://inbox/test_db_file.c4gh

--- a/.github/integration/setup/common/10_services.sh
+++ b/.github/integration/setup/common/10_services.sh
@@ -5,7 +5,7 @@ docker build -t neicnordic/sda-pipeline:latest . || exit 1
 
 cd dev_utils || exit 1
 
-if [ "$STORAGETYPE" = s3notls ]; then
+if [ "$TESTTYPE" = s3notls ]; then
     docker-compose -f compose-no-tls.yml up -d
 
     RETRY_TIMES=0
@@ -22,7 +22,7 @@ if [ "$STORAGETYPE" = s3notls ]; then
         done
     done
 
-elif [ "$STORAGETYPE" = s3notlsheader ]; then
+elif [ "$TESTTYPE" = s3notlsheader ]; then
     sed -i 's/copyHeader: "false"/copyHeader: "true"/g' config-notls.yaml
 
     docker-compose -f compose-no-tls.yml up -d
@@ -48,9 +48,9 @@ else
 
     tostart="certfixer db mq"
 
-    if [ "$STORAGETYPE" = s3 ]; then
+    if [ "$TESTTYPE" = s3 ]; then
         tostart="certfixer db mq s3"
-    elif [ "$STORAGETYPE" = s3header ] || [ "$STORAGETYPE" = posixheader ]; then
+    elif [ "$TESTTYPE" = s3header ] || [ "$TESTTYPE" = posixheader ]; then
         tostart="certfixer db mq s3"
         sed -i 's/copyHeader: "false"/copyHeader: "true"/g' config.yaml
     fi
@@ -93,7 +93,7 @@ else
         done
     done
 
-    if [ "$STORAGETYPE" = s3header ] || [ "$STORAGETYPE" = posixheader ]; then
+    if [ "$TESTTYPE" = s3header ] || [ "$TESTTYPE" = posixheader ]; then
         sed -i 's/copyHeader: "true"/copyHeader: "false"/g' config.yaml
     fi
 

--- a/.github/integration/tests/cancel/40_cancel_test.sh
+++ b/.github/integration/tests/cancel/40_cancel_test.sh
@@ -279,7 +279,7 @@ curl --cacert certs/ca.pem -u test:test 'https://localhost:15672/api/exchanges/t
 							}' | sed -e "s/DECMD5SUM/${decmd5sum}/" -e "s/DECSHA256SUM/${decsha256sum}/" -e "s/ACCESSIONID/${access}/")"
 
 RETRY_TIMES=0
-until docker logs finalize --since="$now" 2>&1 | grep "MarkReady failed"; do
+until docker logs finalize --since="$now" 2>&1 | grep "file is DISABLED, stopping work"; do
 	echo "case4 waiting for finalize to fail"
 	RETRY_TIMES=$((RETRY_TIMES + 1))
 	if [ "$RETRY_TIMES" -eq 60 ]; then

--- a/.github/integration/tests/cancel/40_cancel_test.sh
+++ b/.github/integration/tests/cancel/40_cancel_test.sh
@@ -145,3 +145,68 @@ until docker logs ingest --since="$now" 2>&1 | grep "file is DISABLED, reverting
 	fi
 	sleep 10
 done
+
+## case cancel message arrives before verification has completed
+
+docker pause verify
+
+now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+curl --cacert certs/ca.pem -v -u test:test 'https://localhost:15672/api/exchanges/test/sda/publish' \
+	-H 'Content-Type: application/json;charset=UTF-8' \
+	--data-binary "$(echo '{"vhost":"test", "name":"sda",
+							"properties":{
+								"delivery_mode":2,
+								"correlation_id":"3001",
+								"content_encoding":"UTF-8",
+								"content_type":"application/json"
+							},
+							"routing_key":"files",
+							"payload_encoding":"string",
+							"payload":"{\"type\":\"ingest\",\"user\":\"test3\",\"filepath\":\"largefile.c4gh\",\"encrypted_checksums\":[
+								{\"type\":\"sha256\",\"value\":\"SHA256SUM\"},
+								{\"type\":\"md5\",\"value\":\"MD5SUM\"}
+							]}"
+							}' | sed -e "s/MD5SUM/${md5sum}/" -e "s/SHA256SUM/${sha256sum}/")"
+
+RETRY_TIMES=0
+until docker logs ingest --since="$now" 2>&1 | grep "Wrote archived file"; do
+	echo "waiting for ingestion to complete"
+	RETRY_TIMES=$((RETRY_TIMES + 1))
+	if [ "$RETRY_TIMES" -eq 60 ]; then
+		echo "::error::Time out while waiting for ingest to complete, logs:"
+		docker logs --since="$now" ingest
+		exit 1
+	fi
+	sleep 10
+done
+
+curl --cacert certs/ca.pem -v -u test:test 'https://localhost:15672/api/exchanges/test/sda/publish' \
+	-H 'Content-Type: application/json;charset=UTF-8' \
+	--data-binary "$(echo '{"vhost":"test", "name":"sda",
+							"properties":{
+								"delivery_mode":2,
+								"correlation_id":"3002",
+								"content_encoding":"UTF-8",
+								"content_type":"application/json"
+							},
+							"routing_key":"files",
+							"payload_encoding":"string",
+							"payload":"{\"type\":\"cancel\",\"user\":\"test3\",\"filepath\":\"largefile.c4gh\",\"encrypted_checksums\":[
+								{\"type\":\"sha256\",\"value\":\"SHA256SUM\"},
+								{\"type\":\"md5\",\"value\":\"MD5SUM\"}
+							]}"
+							}' | sed -e "s/MD5SUM/${md5sum}/" -e "s/SHA256SUM/${sha256sum}/")"
+
+docker unpause verify
+
+RETRY_TIMES=0
+until docker logs verify --since="$now" 2>&1 | grep "file is DISABLED, removing from archive"; do
+	echo "waiting for verify to abort"
+	RETRY_TIMES=$((RETRY_TIMES + 1))
+	if [ "$RETRY_TIMES" -eq 60 ]; then
+		echo "::error::Time out while waiting for verify to abort, logs:"
+		docker logs --since="$now" verify
+		exit 10
+	fi
+	sleep 10
+done

--- a/.github/integration/tests/cancel/40_cancel_test.sh
+++ b/.github/integration/tests/cancel/40_cancel_test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+pip3 install s3cmd
+
 cd dev_utils || exit 1
 
 chmod 600 certs/client-key.pem
@@ -75,6 +77,69 @@ until docker logs ingest --since="$now" 2>&1 | grep "File is DISABLED"; do
 	RETRY_TIMES=$((RETRY_TIMES + 1))
 	if [ "$RETRY_TIMES" -eq 60 ]; then
 		echo "::error::Time out while waiting for ingest to be canceled, logs:"
+		docker logs --since="$now" ingest
+		exit 1
+	fi
+	sleep 10
+done
+
+## case cancel message arrives after ingestion has started
+
+s3cmd -c s3cmd.conf put largefile.c4gh s3://inbox/largefile.c4gh
+
+now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+curl --cacert certs/ca.pem -v -u test:test 'https://localhost:15672/api/exchanges/test/sda/publish' \
+	-H 'Content-Type: application/json;charset=UTF-8' \
+	--data-binary "$(echo '{"vhost":"test", "name":"sda",
+							"properties":{
+								"delivery_mode":2,
+								"correlation_id":"2001",
+								"content_encoding":"UTF-8",
+								"content_type":"application/json"
+							},
+							"routing_key":"files",
+							"payload_encoding":"string",
+							"payload":"{\"type\":\"ingest\",\"user\":\"test2\",\"filepath\":\"largefile.c4gh\",\"encrypted_checksums\":[
+								{\"type\":\"sha256\",\"value\":\"SHA256SUM\"},
+								{\"type\":\"md5\",\"value\":\"MD5SUM\"}
+							]}"
+							}' | sed -e "s/MD5SUM/${md5sum}/" -e "s/SHA256SUM/${sha256sum}/")"
+
+RETRY_TIMES=0
+until docker logs ingest --since="$now" 2>&1 | grep "Received work (corr-id: 2001"; do
+	echo "waiting for ingestion to start"
+	RETRY_TIMES=$((RETRY_TIMES + 1))
+	if [ "$RETRY_TIMES" -eq 60 ]; then
+		echo "::error::Time out while waiting for ingest to start, logs:"
+		docker logs --since="$now" ingest
+		exit 1
+	fi
+	sleep 1
+done
+
+curl --cacert certs/ca.pem -v -u test:test 'https://localhost:15672/api/exchanges/test/sda/publish' \
+	-H 'Content-Type: application/json;charset=UTF-8' \
+	--data-binary "$(echo '{"vhost":"test", "name":"sda",
+							"properties":{
+								"delivery_mode":2,
+								"correlation_id":"2002",
+								"content_encoding":"UTF-8",
+								"content_type":"application/json"
+							},
+							"routing_key":"files",
+							"payload_encoding":"string",
+							"payload":"{\"type\":\"cancel\",\"user\":\"test2\",\"filepath\":\"largefile.c4gh\",\"encrypted_checksums\":[
+								{\"type\":\"sha256\",\"value\":\"SHA256SUM\"},
+								{\"type\":\"md5\",\"value\":\"MD5SUM\"}
+							]}"
+							}' | sed -e "s/MD5SUM/${md5sum}/" -e "s/SHA256SUM/${sha256sum}/")"
+
+RETRY_TIMES=0
+until docker logs ingest --since="$now" 2>&1 | grep "file is DISABLED, reverting changes"; do
+	echo "waiting for ingestion to abort"
+	RETRY_TIMES=$((RETRY_TIMES + 1))
+	if [ "$RETRY_TIMES" -eq 60 ]; then
+		echo "::error::Time out while waiting for ingest to abort, logs:"
 		docker logs --since="$now" ingest
 		exit 1
 	fi

--- a/.github/integration/tests/cancel/40_cancel_test.sh
+++ b/.github/integration/tests/cancel/40_cancel_test.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+cd dev_utils || exit 1
+
+chmod 600 certs/client-key.pem
+
+now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+C4GH_PASSPHRASE=$(grep -F passphrase config.yaml | sed -e 's/.* //' -e 's/"//g')
+export C4GH_PASSPHRASE
+
+md5sum=$(md5sum largefile.c4gh  | cut -d' ' -f 1)
+sha256sum=$(sha256sum largefile.c4gh | cut -d' ' -f 1)
+
+dcf=$(mktemp)
+
+decsha256sum=$(crypt4gh decrypt --sk c4gh.sec.pem <largefile.c4gh  | LANG=C dd bs=4M 2>"$dcf" | sha256sum | cut -d' ' -f 1)
+decmd5sum=$(crypt4gh decrypt --sk c4gh.sec.pem <largefile.c4gh  | md5sum | cut -d' ' -f 1)
+
+rm -f "$dcf"
+
+## case cancel message arrives before ingestion has started
+
+docker pause ingest
+
+curl --cacert certs/ca.pem -v -u test:test 'https://localhost:15672/api/exchanges/test/sda/publish' \
+	-H 'Content-Type: application/json;charset=UTF-8' \
+	--data-binary "$(echo '{"vhost":"test", "name":"sda",
+							"properties":{
+								"delivery_mode":2,
+								"correlation_id":"1001",
+								"content_encoding":"UTF-8",
+								"content_type":"application/json"
+							},
+							"routing_key":"files",
+							"payload_encoding":"string",
+							"payload":"{\"type\":\"ingest\",\"user\":\"test1\",\"filepath\":\"largefile.c4gh\",\"encrypted_checksums\":[
+								{\"type\":\"sha256\",\"value\":\"SHA256SUM\"},
+								{\"type\":\"md5\",\"value\":\"MD5SUM\"}
+							]}"
+							}' | sed -e "s/MD5SUM/${md5sum}/" -e "s/SHA256SUM/${sha256sum}/")"
+
+curl --cacert certs/ca.pem -v -u test:test 'https://localhost:15672/api/exchanges/test/sda/publish' \
+	-H 'Content-Type: application/json;charset=UTF-8' \
+	--data-binary "$(echo '{"vhost":"test", "name":"sda",
+							"properties":{
+								"delivery_mode":2,
+								"correlation_id":"1002",
+								"content_encoding":"UTF-8",
+								"content_type":"application/json"
+							},
+							"routing_key":"files",
+							"payload_encoding":"string",
+							"payload":"{\"type\":\"cancel\",\"user\":\"test1\",\"filepath\":\"largefile.c4gh\",\"encrypted_checksums\":[
+								{\"type\":\"sha256\",\"value\":\"SHA256SUM\"},
+								{\"type\":\"md5\",\"value\":\"MD5SUM\"}
+							]}"
+							}' | sed -e "s/MD5SUM/${md5sum}/" -e "s/SHA256SUM/${sha256sum}/")"
+
+status=$(docker run --rm --name client --network dev_utils_default -v "$PWD/certs:/certs" \
+	-e PGSSLCERT=/certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
+	neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
+	-t -A -c "SELECT status from local_ega.files where inbox_path='largefile.c4gh' and elixir_id='test1';")
+
+if [ "$status" != "DISABLED" ]; then
+	echo "cancel before ingestion failed, expected DISABLED got: $status"
+	docker logs intercept --since="$now"
+	exit 1
+fi

--- a/.github/integration/tests/cancel/40_cancel_test.sh
+++ b/.github/integration/tests/cancel/40_cancel_test.sh
@@ -66,3 +66,17 @@ if [ "$status" != "DISABLED" ]; then
 	docker logs intercept --since="$now"
 	exit 1
 fi
+
+docker unpause ingest
+
+RETRY_TIMES=0
+until docker logs ingest --since="$now" 2>&1 | grep "File is DISABLED"; do
+	echo "waiting for ingestion to be canceled"
+	RETRY_TIMES=$((RETRY_TIMES + 1))
+	if [ "$RETRY_TIMES" -eq 60 ]; then
+		echo "::error::Time out while waiting for ingest to be canceled, logs:"
+		docker logs --since="$now" ingest
+		exit 1
+	fi
+	sleep 10
+done

--- a/.github/integration/tests/common/10_trigger_failures.sh
+++ b/.github/integration/tests/common/10_trigger_failures.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$TESTTYPE" = s3notls ] || [ "$TESTTYPE" = s3notlsheader ]; then
+if [ "$TESTTYPE" = s3notls ] || [ "$TESTTYPE" = s3notlsheader ]|| [ "$TESTTYPE" = cancel ]; then
     exit 0
 fi
 

--- a/.github/integration/tests/common/10_trigger_failures.sh
+++ b/.github/integration/tests/common/10_trigger_failures.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$STORAGETYPE" = s3notls ] || [ "$STORAGETYPE" = s3notlsheader ]; then
+if [ "$TESTTYPE" = s3notls ] || [ "$TESTTYPE" = s3notlsheader ]; then
     exit 0
 fi
 
@@ -113,7 +113,7 @@ curl --cacert certs/ca.pem  -vvv -u test:test 'https://localhost:15672/api/excha
 
 # Verify that message is moved to the error queue (takes a few mins).
 
-if [ "$STORAGETYPE" = posix ] || [ "$STORAGETYPE" = posixheader ]; then
+if [ "$TESTTYPE" = posix ] || [ "$TESTTYPE" = posixheader ]; then
 	check_move_to_error_queue "no such file or directory"
 else
 	check_move_to_error_queue "NoSuchKey: The specified key does not exist."

--- a/.github/integration/tests/common/30_ingest_test.sh
+++ b/.github/integration/tests/common/30_ingest_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$TESTTYPE" = s3notls ] || [ "$TESTTYPE" = s3notlsheader ]; then
+if [ "$TESTTYPE" = s3notls ] || [ "$TESTTYPE" = s3notlsheader ]|| [ "$TESTTYPE" = cancel ]; then
     exit 0
 fi
 

--- a/.github/integration/tests/common/30_ingest_test.sh
+++ b/.github/integration/tests/common/30_ingest_test.sh
@@ -124,23 +124,6 @@ for file in dummy_data.c4gh largefile.c4gh; do
 		sleep 10
 	done
 
-	RETRY_TIMES=0
-	until docker logs verify --since="$now" 2>&1 | grep "Removed file from inbox"; do
-		echo "waiting for verify to remove file from inbox"
-		RETRY_TIMES=$((RETRY_TIMES + 1))
-		if [ "$RETRY_TIMES" -eq 10 ]; then
-			echo "::error::Time out while waiting for verify to remove file, logs:"
-
-			echo
-			echo verify
-			echo
-
-			docker logs --since="$now" verify
-			exit 1
-		fi
-		sleep 10
-	done
-
 	now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 	access=$(printf "EGAF%05d%06d" "$RANDOM" "$count")
 

--- a/.github/integration/tests/common/30_ingest_test.sh
+++ b/.github/integration/tests/common/30_ingest_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$STORAGETYPE" = s3notls ] || [ "$STORAGETYPE" = s3notlsheader ]; then
+if [ "$TESTTYPE" = s3notls ] || [ "$TESTTYPE" = s3notlsheader ]; then
     exit 0
 fi
 

--- a/.github/integration/tests/common/8_bad_messages.sh
+++ b/.github/integration/tests/common/8_bad_messages.sh
@@ -17,7 +17,7 @@ function check_move_to_error_queue() {
 	RETRY_TIMES=0
 	echo
 	echo "Waiting for msg containing \"""$1""\" to move to error queue."
-	until curl --cacert certs/ca.pem  -u test:test 'https://localhost:15672/api/queues/test/error/get' \
+	until curl --cacert certs/ca.pem -u test:test 'https://localhost:15672/api/queues/test/error/get' \
 		-H 'Content-Type: application/json;charset=UTF-8' \
 		-d '{"count":1,"ackmode":"ack_requeue_false","encoding":"auto","truncate":50000}' 2>&1 | grep -q "$1"; do
 		printf '%s' "."
@@ -39,7 +39,7 @@ function check_move_to_error_queue() {
 	echo
 }
 
-for routingkey in files ingest archived accessionIDs backup mappings; do
+for routingkey in files ingest; do
 	curl --cacert certs/ca.pem -vvv -u test:test 'https://localhost:15672/api/exchanges/test/sda/publish' \
 		-H 'Content-Type: application/json;charset=UTF-8' \
 		--data-binary '{
@@ -53,15 +53,14 @@ for routingkey in files ingest archived accessionIDs backup mappings; do
 						},
 						"routing_key":"'"$routingkey"'",
 						"payload_encoding":"string",
-						"payload":"{
-						I give you bad json!}"
+						"payload":"{I give you bad json!}"
 					}'
 
 check_move_to_error_queue "I give you bad json"
 
 done
 
-for routingkey in files ingest archived accessionIDs backup mappings; do
+for routingkey in files ingest; do
 	curl --cacert certs/ca.pem -vvv -u test:test 'https://localhost:15672/api/exchanges/test/sda/publish' \
 		-H 'Content-Type: application/json;charset=UTF-8' \
 		--data-binary '{

--- a/.github/integration/tests/common/8_bad_messages.sh
+++ b/.github/integration/tests/common/8_bad_messages.sh
@@ -5,7 +5,7 @@
 # before the "real" work to verify that these failures are not top of
 # queue and handled again and again.
 #
-if [ "$STORAGETYPE" = s3notls ] || [ "$STORAGETYPE" = s3notlsheader ]; then
+if [ "$TESTTYPE" = s3notls ] || [ "$TESTTYPE" = s3notlsheader ] ; then
     exit 0
 fi
 

--- a/.github/integration/tests/s3notls/40_ingest_test_notls.sh
+++ b/.github/integration/tests/s3notls/40_ingest_test_notls.sh
@@ -115,23 +115,6 @@ for file in dummy_data.c4gh largefile.c4gh; do
 		sleep 10
 	done
 
-	RETRY_TIMES=0
-	until docker logs verify --since="$now" 2>&1 | grep "Removed file from inbox"; do
-		echo "waiting for verify to remove file from inbox"
-		RETRY_TIMES=$((RETRY_TIMES + 1))
-		if [ "$RETRY_TIMES" -eq 10 ]; then
-			echo "::error::Time out while waiting for verify to remove file, logs:"
-
-			echo
-			echo verify
-			echo
-
-			docker logs --since="$now" verify
-			exit 1
-		fi
-		sleep 10
-	done
-
 	now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 	access=$(printf "EGAF%05d%06d" "$RANDOM" "$count")
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        testtype: [s3, posix, s3notls, s3header, s3notlsheader, posixheader]
+        testtype: [s3, posix, s3notls, s3header, s3notlsheader, posixheader, cancel]
 
     steps:
       - name: Set up Python

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,14 +5,14 @@ on: [pull_request]
 
 jobs:
   integrationtests:
-    name: integration-${{ matrix.storagetype }}
+    name: integration-${{ matrix.testtype }}
     runs-on: ubuntu-latest
     env:
-      STORAGETYPE: ${{ matrix.storagetype }}
+      TESTTYPE: ${{ matrix.testtype }}
 
     strategy:
       matrix:
-        storagetype: [s3, posix, s3notls, s3header, s3notlsheader, posixheader]
+        testtype: [s3, posix, s3notls, s3header, s3notlsheader, posixheader]
 
     steps:
       - name: Set up Python
@@ -25,13 +25,13 @@ jobs:
 
       - name: Run setup scripts
         run: 'set -e;
-              ls -1 .github/integration/setup/{common,${{ matrix.storagetype }}}/*.sh 2>/dev/null | sort -t/ -k5 -n | while read -r runscript; do
+              ls -1 .github/integration/setup/{common,${{ matrix.testtype }}}/*.sh 2>/dev/null | sort -t/ -k5 -n | while read -r runscript; do
                  echo "Executing setup script $runscript";
                  bash -x "$runscript";
               done'
 
       - name: Run tests
-        run: 'ls -1 .github/integration/tests/{common,${{ matrix.storagetype }}}/*.sh 2>/dev/null | sort -t/ -k5 -n | while read -r runscript; do
+        run: 'ls -1 .github/integration/tests/{common,${{ matrix.testtype }}}/*.sh 2>/dev/null | sort -t/ -k5 -n | while read -r runscript; do
                 echo "Executing test script $runscript";
                 bash -x "$runscript";
               done'

--- a/cmd/finalize/finalize.md
+++ b/cmd/finalize/finalize.md
@@ -3,12 +3,15 @@
 Handles the so-called _Accession ID (stable ID)_ to filename mappings from Central EGA.
 
 ## Service Description
+
 Finalize adds stable, shareable _Accession ID_'s to archive files.
 When running, finalize reads messages from the configured RabbitMQ queue (default "accessionIDs").
 For each message, these steps are taken (if not otherwise noted, errors halt progress and the service moves on to the next message):
 
 1. The message is validated as valid JSON that matches the "ingestion-accession" schema (defined in sda-common).
 If the message can’t be validated it is discarded with an error message in the logs.
+
+1. A check is performed to get the status of the file that is to be verified, if the status is `DISABLED` the work is aborted and the message will be acked.
 
 1. if the type of the `DecryptedChecksums` field in the message is `sha256`, the value is stored.
 

--- a/cmd/ingest/ingest.go
+++ b/cmd/ingest/ingest.go
@@ -427,6 +427,7 @@ func main() {
 				continue
 			}
 			if status == "DISABLED" {
+				log.Debugln("file is DISABLED, reverting changes")
 				if err := archive.RemoveFile(archivedFile); err != nil {
 					log.Errorf("Failed to remove file from archive: %v", err)
 				}

--- a/cmd/ingest/ingest.go
+++ b/cmd/ingest/ingest.go
@@ -113,7 +113,7 @@ func main() {
 			_ = json.Unmarshal(delivered.Body, &message)
 
 
-			ID, err := db.GetFileID(message.Filepath, message.User)
+			fileID, err := db.GetFileID(message.Filepath, message.User)
 			if err != nil {
 				log.Errorf("Failed to get file id: %v", err)
 
@@ -124,7 +124,7 @@ func main() {
 				continue
 			}
 
-			status, err := db.GetStatus(ID)
+			status, err := db.GetStatus(fileID)
 			if err != nil {
 				log.Errorf("Failed to check file status: %v", err)
 
@@ -254,17 +254,6 @@ func main() {
 						archivedFile,
 						e)
 				}
-				continue
-			}
-
-			fileID, err := db.GetFileID(message.Filepath, message.User)
-			if err != nil {
-				log.Errorf("Failed to get file id: %v", err)
-
-				if err := delivered.Nack(false, true); err != nil {
-					log.Errorf("Failed to nack message: %v", err)
-				}
-
 				continue
 			}
 

--- a/cmd/ingest/ingest.go
+++ b/cmd/ingest/ingest.go
@@ -136,6 +136,7 @@ func main() {
 			}
 
 			if status == "DISABLED" {
+				log.Debugln("File is DISABLED, canceling ingestion")
 				if err := delivered.Ack(false); err != nil {
 					log.Errorf("Failed to ack message: %v", err)
 				}

--- a/cmd/intercept/intercept.go
+++ b/cmd/intercept/intercept.go
@@ -134,6 +134,11 @@ func main() {
 				log.Debugln("mark file as DISABLED")
 				if err := db.DisableFile(message["filepath"].(string), message["user"].(string)); err != nil {
 					log.Errorf("MarkDisabled failed: %v", err)
+					if err := delivered.Nack(false, true); err != nil {
+						log.Errorf("Failed to nack message: %v", err)
+					}
+
+					continue
 				}
 
 				if err := delivered.Ack(false); err != nil {

--- a/cmd/intercept/intercept.go
+++ b/cmd/intercept/intercept.go
@@ -131,7 +131,7 @@ func main() {
 			case msgCancel:
 				message := make(map[string]interface{})
 				_ = json.Unmarshal(delivered.Body, &message)
-
+				log.Debugln("mark file as DISABLED")
 				if err := db.DisableFile(message["filepath"].(string), message["user"].(string)); err != nil {
 					log.Errorf("MarkDisabled failed: %v", err)
 				}
@@ -150,6 +150,7 @@ func main() {
 				if err != nil {
 					switch err.Error() {
 					case "sql: no rows in result set":
+						log.Debugln("inserting file in DB")
 						ID, err = db.InsertFile(message["filepath"].(string), message["user"].(string))
 						if err != nil {
 							log.Errorf("InsertFile failed: %v", err)
@@ -171,6 +172,7 @@ func main() {
 				}
 
 				status, err := db.GetStatus(ID)
+				log.Debugf("status: %v", status)
 				if err != nil {
 					log.Errorf("Failed to check file status: %v", err)
 

--- a/cmd/intercept/intercept.md
+++ b/cmd/intercept/intercept.md
@@ -15,6 +15,10 @@ Then the service moves on to the next message):
 1. The message is validated as valid JSON following the schema read in the previous step.
 If this fails an error is written to the logs, but not to the error queue and the message is not Ack'ed or Nack'ed.
 
+1. If the message is of type `cancel`, the file will be marked as `DISABLED` in the database.
+
+1. If the message is of type `ingest` an entry will be inserted in the database unless it already exists.
+
 1. The correct queue for the message is decided based on message type.
 This is not supposed to be able to fail.
 
@@ -22,4 +26,3 @@ This is not supposed to be able to fail.
 This has no error handling as the resend-mechanism hasn't been finished.
 
 1. The message is Ack'ed.
-

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -119,6 +119,7 @@ func main() {
 				continue
 			}
 			if status == "DISABLED" {
+				log.Debugln("file is DISABLED, removing from archive")
 				if err := archive.RemoveFile(message.ArchivePath); err != nil {
 					log.Errorf("Failed to remove file from archive: %v", err)
 				}
@@ -355,6 +356,7 @@ func main() {
 					continue
 				}
 				if status == "DISABLED" {
+					log.Debugln("file is DISABLED, removing from archive")
 					if err := archive.RemoveFile(message.ArchivePath); err != nil {
 						log.Errorf("Failed to remove file from archive: %v", err)
 					}

--- a/cmd/verify/verify.md
+++ b/cmd/verify/verify.md
@@ -13,6 +13,8 @@ Unless explicitly stated, error messages are *not* written to the RabbitMQ error
 1. The message is validated as valid JSON that matches the "ingestion-verification" schema (defined in sda-common).
 If the message can’t be validated it is discarded with an error message in the logs.
 
+1. A check is performed to get the status of the file that is to be verified, if the status is `DISABLED` the work is aborted, the file will be removed from the archive and the message will be acked.
+
 1. The service attempts to fetch the header for the file id in the message from the database.
 If this fails a NACK will be sent for the RabbitMQ message, the error will be written to the logs, and sent to the RabbitMQ error queue.
 
@@ -34,6 +36,8 @@ Otherwise the processing continues with verification:
     1. A verification message is created, and validated against the "ingestion-accession-request" schema.
     If this fails an error will be written to the logs.
 
+    1. A check is performed to get the status of the file, if the status is `DISABLED` the work is aborted, the file will be removed from the archive and the message will be acked.
+
     1. The file is marked as *verified* in the database (*COMPLETED* if you are using database schema <= 3).
     If this fails an error will be written to the logs.
 
@@ -45,4 +49,3 @@ Otherwise the processing continues with verification:
 
     1. The archive file is removed from the inbox storage.
     If this fails an error is written to the logs, and an error is written to the error queue.
-

--- a/dev_utils/compose-no-tls.yml
+++ b/dev_utils/compose-no-tls.yml
@@ -173,14 +173,18 @@ services:
     restart: always
   interceptor:
     command: sda-intercept
+    container_name: intercept
     depends_on:
       - mq
+      - db
     environment:
       - BROKER_EXCHANGE=sda
       - BROKER_HOST=mq
       - BROKER_QUEUE=files
-      - BROKER_ROUTINGKEY=ingest
       - BROKER_ROUTINGERROR=error
+      - DB_HOST=db
+      - DB_USER=lega_in
+      - DB_PASSWORD=lega_in
     image: neicnordic/sda-pipeline:latest
     volumes:
       - ./config-notls.yaml:/config.yaml

--- a/dev_utils/compose-sda.yml
+++ b/dev_utils/compose-sda.yml
@@ -185,9 +185,9 @@ services:
     depends_on: 
       - certfixer
       - mq
+      - db
     env_file: ./env.intercept
     image: neicnordic/sda-pipeline:latest
-    
     volumes:
       - ./config.yaml:/config.yaml
       - ./:/dev_utils/

--- a/dev_utils/run_tests.sh
+++ b/dev_utils/run_tests.sh
@@ -17,31 +17,29 @@ python3 -m venv "$tmpdir"
 
 export STORAGETYPE
 for storage in s3 posix; do
-    git checkout dev_utils/env.*
+	git checkout dev_utils/env.*
 
-    STORAGETYPE=$storage
+	export TESTTYPE=$storage
 
-    for runscript in $(find . -maxdepth 1 -name ".github/integration/setup/{common,${storage}}/*.sh" 2>/dev/null | sort -t/ -k5 -n); do
-	echo "Executing setup script $runscript";
-	if bash -x "$runscript"; then
-	    :
-	else
-	    echo "Setup failed"
-	    rm -rf "$tmpdir"
-	    exit 1
-	fi
-    done
-    
-    for runscript in $(find . -maxdepth 1 -name ".github/integration/tests/{common,${storage}}/*.sh" 2>/dev/null | sort -t/ -k5 -n); do
-	echo "Executing test script $runscript";
-	if bash -x "$runscript"; then
-	    :
-	else
-	    echo "$runscript failed, bailing out"
-	    rm -rf "$tmpdir"
-	    exit 1
-	fi
-    done
+	for runscript in $(find . -maxdepth 1 -name ".github/integration/setup/{common,${storage}}/*.sh" 2>/dev/null | sort -t/ -k5 -n); do
+		echo "Executing setup script $runscript"
+		if bash -x "$runscript"; then
+			:
+		else
+			echo "Setup failed"
+			rm -rf "$tmpdir"
+			exit 1
+		fi
+	done
+
+	for runscript in $(find . -maxdepth 1 -name ".github/integration/tests/{common,${storage}}/*.sh" 2>/dev/null | sort -t/ -k5 -n); do
+		echo "Executing test script $runscript"
+		if bash -x "$runscript"; then
+			:
+		else
+			echo "$runscript failed, bailing out"
+			rm -rf "$tmpdir"
+			exit 1
+		fi
+	done
 done
-
-

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -93,9 +93,8 @@ func NewConfig(app string) (*Config, error) {
 			"broker.host", "broker.port", "broker.user", "broker.password", "broker.routingkey", "db.host", "db.port", "db.user", "db.password", "db.database",
 		}
 	case "intercept":
-		// Intercept does not require these extra settings
 		requiredConfVars = []string{
-			"broker.host", "broker.port", "broker.user", "broker.password", "broker.queue",
+			"broker.host", "broker.port", "broker.user", "broker.password", "broker.queue", "db.host", "db.port", "db.user", "db.password", "db.database",
 		}
 	case "mapper":
 		// Mapper does not require broker.routingkey thus we remove it
@@ -184,6 +183,11 @@ func NewConfig(app string) (*Config, error) {
 		}
 		return c, nil
 	case "intercept":
+		err = c.configDatabase()
+		if err != nil {
+			return nil, err
+		}
+
 		return c, nil
 	case "verify":
 		c.configInbox()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -534,6 +534,12 @@ func (suite *TestSuite) TestInterceptConfiguration() {
 	assert.Equal(suite.T(), "test", config.Broker.Queue)
 	assert.Equal(suite.T(), "test", config.Broker.RoutingKey)
 	assert.Equal(suite.T(), "test", config.Broker.Exchange)
+	assert.NotNil(suite.T(), config.Database)
+	assert.Equal(suite.T(), "test", config.Database.Host)
+	assert.Equal(suite.T(), 123, config.Database.Port)
+	assert.Equal(suite.T(), "test", config.Database.User)
+	assert.Equal(suite.T(), "test", config.Database.Password)
+	assert.Equal(suite.T(), "test", config.Database.Database)
 
 	// Clear variables
 	viper.Reset()
@@ -549,6 +555,11 @@ func (suite *TestSuite) TestInterceptConfiguration() {
 	viper.Set("broker.user", "test")
 	viper.Set("broker.password", "test")
 	viper.Set("broker.queue", "test")
+	viper.Set("db.host", "test")
+	viper.Set("db.port", 123)
+	viper.Set("db.user", "test")
+	viper.Set("db.password", "test")
+	viper.Set("db.database", "test")
 
 	// Now we should have enough
 	config, err = NewConfig("intercept")

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -469,7 +469,7 @@ func (dbs *SQLdb) Close() {
 	db.Close()
 }
 
-// DisableFile marks the file as 'DISABLE'
+// DisableFile marks the file as 'DISABLED'
 func (dbs *SQLdb) DisableFile(filePath, user string) error {
 	var err error
 	for count := 1; count <= dbRetryTimes; count++ {
@@ -497,7 +497,7 @@ func (dbs *SQLdb) disableFile(filePath, user string) error {
 	return nil
 }
 
-// GetStatus returnes the status for a given fileID
+// GetStatus returns the status for a given fileID
 func (dbs *SQLdb) GetStatus(fileID int64) (string, error) {
 	status, err := dbs.getStatus(fileID)
 	if err != nil {
@@ -519,7 +519,7 @@ func (dbs *SQLdb) getStatus(fileID int64) (string, error) {
 	return status, nil
 }
 
-// GetFileID returnes the ID for a given inbox path and user combination
+// GetFileID returns the ID for a given inbox path and user combination
 func (dbs *SQLdb) GetFileID(filePath, user string) (int64, error) {
 	fileID, err := dbs.getFileID(filePath, user)
 	if err != nil {


### PR DESCRIPTION
POC of how to handle `cancel` messages from EGA.

`intercept` marks a file as `canceled` when a `cancel` message arrives, the message is then discarded.
On a `ingest` message `intercept` checks if the file exists in the DB, if not it inserts the file in the DB. If the file exists and has status `CANCELED` the status is set to `INIT`

`ingest` needs to check if a file has been marked as `canceled` before any work is started and before writing the state to the DB that signals that the work is completed.
* If ingestion has not started no further actions will be taken.
* If the file has gone through ingestion it will be removed from the archive.

`verify` needs to check if a file has been marked as `canceled` before any work is started and before writing the state to the DB that signals that the work is completed.
`verify` will no longer remove files from the inbox, this should be done only once a file has been given a stable ID.
* Since the file has gone through ingestion it will be removed from the archive.

- [x] cancel message arrives after ingest has started
- [x] cancel message arrives before ingest has started
- [x] cancel message arrives after ingest has completed
- [x] re-ingestion of a canceled file
- [x] Integration test for cancel messages


closes #484 