### PR TITLE
Graceful shutdown

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -28,8 +28,7 @@ func main() {
 
 	Conf, err = config.NewConfig("api")
 	if err != nil {
-		log.Error(err)
-		sigc <- syscall.SIGINT
+		log.Fatal(err)
 	}
 	Conf.API.MQ, err = broker.NewMQ(Conf.Broker)
 	if err != nil {

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -93,9 +93,13 @@ func setup(config *config.Config) *http.Server {
 }
 
 func shutdown() {
-	defer Conf.API.MQ.Channel.Close()
-	defer Conf.API.MQ.Connection.Close()
-	defer Conf.API.DB.Close()
+	if Conf.API.MQ != nil {
+		Conf.API.MQ.Channel.Close()
+		Conf.API.MQ.Connection.Close()
+	}
+	if Conf.API.DB != nil {
+		Conf.API.DB.Close()
+	}
 }
 
 func readinessResponse(w http.ResponseWriter, r *http.Request) {

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -19,6 +19,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// Conf needs to be exported or the shutdown will not run properly
 var Conf *config.Config
 var err error
 

--- a/cmd/backup/backup.go
+++ b/cmd/backup/backup.go
@@ -84,9 +84,13 @@ func main() {
 	signal.Notify(sigc, os.Interrupt, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 	go func() {
 		<-sigc
-		mq.Channel.Close()
-		mq.Connection.Close()
-		db.Close()
+		if mq != nil {
+			defer mq.Channel.Close()
+			defer mq.Connection.Close()
+		}
+		if db != nil {
+			defer db.Close()
+		}
 		os.Exit(1)
 	}()
 

--- a/cmd/backup/backup.go
+++ b/cmd/backup/backup.go
@@ -41,8 +41,7 @@ func main() {
 
 	conf, err := config.NewConfig("backup")
 	if err != nil {
-		log.Error(err)
-		sigc <- syscall.SIGINT
+		log.Fatal(err)
 	}
 	mq, err := broker.NewMQ(conf.Broker)
 	if err != nil {

--- a/cmd/finalize/finalize.go
+++ b/cmd/finalize/finalize.go
@@ -59,9 +59,13 @@ func main() {
 	signal.Notify(sigc, os.Interrupt, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 	go func() {
 		<-sigc
-		mq.Channel.Close()
-		mq.Connection.Close()
-		db.Close()
+		if mq != nil {
+			defer mq.Channel.Close()
+			defer mq.Connection.Close()
+		}
+		if db != nil {
+			defer db.Close()
+		}
 		os.Exit(1)
 	}()
 

--- a/cmd/finalize/finalize.go
+++ b/cmd/finalize/finalize.go
@@ -43,8 +43,7 @@ func main() {
 
 	conf, err := config.NewConfig("finalize")
 	if err != nil {
-		log.Error(err)
-		sigc <- syscall.SIGINT
+		log.Fatal(err)
 	}
 	mq, err := broker.NewMQ(conf.Broker)
 	if err != nil {

--- a/cmd/finalize/finalize.go
+++ b/cmd/finalize/finalize.go
@@ -39,45 +39,52 @@ type completed struct {
 }
 
 func main() {
-	sigc := make(chan os.Signal, 5)
+	forever := make(chan bool, 1)
+	sigc := make(chan os.Signal, 1)
+	signal.Notify(sigc, os.Interrupt, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+
+	defer func() {
+		if r := recover(); r != nil {
+			log.Infoln("Recovered")
+		}
+	}()
+
+	go func() {
+		<-sigc
+		forever <- false
+	}()
 
 	conf, err := config.NewConfig("finalize")
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		sigc <- syscall.SIGINT
+		panic(err)
 	}
 	mq, err := broker.NewMQ(conf.Broker)
 	if err != nil {
 		log.Error(err)
 		sigc <- syscall.SIGINT
+		panic(err)
 	}
+	defer mq.Channel.Close()
+	defer mq.Connection.Close()
+
 	db, err := database.NewDB(conf.Database)
 	if err != nil {
 		log.Error(err)
 		sigc <- syscall.SIGINT
+		panic(err)
 	}
-
-	signal.Notify(sigc, os.Interrupt, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
-	go func() {
-		<-sigc
-		if mq != nil {
-			defer mq.Channel.Close()
-			defer mq.Connection.Close()
-		}
-		if db != nil {
-			defer db.Close()
-		}
-		os.Exit(1)
-	}()
+	defer db.Close()
 
 	go func() {
 		connError := mq.ConnectionWatcher()
 		if connError != nil {
 			log.Errorf("Broker connError: %v", connError)
-			sigc <- syscall.SIGINT
+			sigc <- syscall.SIGTERM
+			panic(connError)
 		}
 	}()
-
-	forever := make(chan bool)
 
 	log.Info("Starting finalize service")
 	var message finalize
@@ -87,6 +94,7 @@ func main() {
 		if err != nil {
 			log.Error(err)
 			sigc <- syscall.SIGINT
+			panic(err)
 		}
 		for delivered := range messages {
 			log.Debugf("Received a message (corr-id: %s, message: %s)",

--- a/cmd/ingest/ingest.go
+++ b/cmd/ingest/ingest.go
@@ -84,9 +84,13 @@ func main() {
 	signal.Notify(sigc, os.Interrupt, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 	go func() {
 		<-sigc
-		mq.Channel.Close()
-		mq.Connection.Close()
-		db.Close()
+		if mq != nil {
+			defer mq.Channel.Close()
+			defer mq.Connection.Close()
+		}
+		if db != nil {
+			defer db.Close()
+		}
 		os.Exit(1)
 	}()
 

--- a/cmd/ingest/ingest.go
+++ b/cmd/ingest/ingest.go
@@ -53,8 +53,7 @@ func main() {
 
 	conf, err := config.NewConfig("ingest")
 	if err != nil {
-		log.Error(err)
-		sigc <- syscall.SIGINT
+		log.Fatal(err)
 	}
 	mq, err := broker.NewMQ(conf.Broker)
 	if err != nil {

--- a/cmd/ingest/ingest.go
+++ b/cmd/ingest/ingest.go
@@ -49,60 +49,71 @@ type checksums struct {
 }
 
 func main() {
-	sigc := make(chan os.Signal, 5)
+	forever := make(chan bool, 1)
+	sigc := make(chan os.Signal, 1)
+	signal.Notify(sigc, os.Interrupt, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+
+	defer func() {
+		if r := recover(); r != nil {
+			log.Infoln("Recovered")
+		}
+	}()
+
+	go func() {
+		<-sigc
+		forever <- false
+	}()
 
 	conf, err := config.NewConfig("ingest")
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		sigc <- syscall.SIGINT
+		panic(err)
 	}
 	mq, err := broker.NewMQ(conf.Broker)
 	if err != nil {
 		log.Error(err)
 		sigc <- syscall.SIGINT
+		panic(err)
 	}
+	defer mq.Channel.Close()
+	defer mq.Connection.Close()
+
 	db, err := database.NewDB(conf.Database)
 	if err != nil {
 		log.Error(err)
 		sigc <- syscall.SIGINT
+		panic(err)
 	}
+	defer db.Close()
+
 	key, err := config.GetC4GHKey()
 	if err != nil {
 		log.Error(err)
 		sigc <- syscall.SIGINT
+		panic(err)
 	}
 	archive, err := storage.NewBackend(conf.Archive)
 	if err != nil {
 		log.Error(err)
 		sigc <- syscall.SIGINT
+		panic(err)
 	}
 	inbox, err := storage.NewBackend(conf.Inbox)
 	if err != nil {
 		log.Error(err)
 		sigc <- syscall.SIGINT
+		panic(err)
 	}
-
-	signal.Notify(sigc, os.Interrupt, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
-	go func() {
-		<-sigc
-		if mq != nil {
-			defer mq.Channel.Close()
-			defer mq.Connection.Close()
-		}
-		if db != nil {
-			defer db.Close()
-		}
-		os.Exit(1)
-	}()
 
 	go func() {
 		connError := mq.ConnectionWatcher()
 		if connError != nil {
 			log.Errorf("Broker connError: %v", connError)
-			sigc <- syscall.SIGINT
+			sigc <- syscall.SIGTERM
+			panic(connError)
 		}
 	}()
-
-	forever := make(chan bool)
 
 	log.Info("starting ingest service")
 	var message trigger
@@ -112,6 +123,7 @@ func main() {
 		if err != nil {
 			log.Error(err)
 			sigc <- syscall.SIGINT
+			panic(err)
 		}
 	mainWorkLoop:
 		for delivered := range messages {

--- a/cmd/ingest/ingest.go
+++ b/cmd/ingest/ingest.go
@@ -518,7 +518,6 @@ func tryDecrypt(key *[32]byte, buf []byte) ([]byte, error) {
 		log.Error(err)
 
 		return nil, err
-
 	}
 	_, err = b.ReadByte()
 	if err != nil {

--- a/cmd/intercept/intercept.go
+++ b/cmd/intercept/intercept.go
@@ -38,8 +38,8 @@ func main() {
 	signal.Notify(sigc, os.Interrupt, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 	go func() {
 		<-sigc
-		mq.Channel.Close()
-		mq.Connection.Close()
+		defer mq.Channel.Close()
+		defer mq.Connection.Close()
 		os.Exit(1)
 	}()
 

--- a/cmd/intercept/intercept.go
+++ b/cmd/intercept/intercept.go
@@ -28,13 +28,11 @@ func main() {
 
 	conf, err := config.NewConfig("intercept")
 	if err != nil {
-		log.Error(err)
-		sigc <- syscall.SIGINT
+		log.Fatal(err)
 	}
 	mq, err := broker.NewMQ(conf.Broker)
 	if err != nil {
-		log.Error(err)
-		sigc <- syscall.SIGINT
+		log.Fatal(err)
 	}
 
 	signal.Notify(sigc, os.Interrupt, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)

--- a/cmd/mapper/mapper.go
+++ b/cmd/mapper/mapper.go
@@ -42,9 +42,13 @@ func main() {
 	signal.Notify(sigc, os.Interrupt, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 	go func() {
 		<-sigc
-		mq.Channel.Close()
-		mq.Connection.Close()
-		db.Close()
+		if mq != nil {
+			defer mq.Channel.Close()
+			defer mq.Connection.Close()
+		}
+		if db != nil {
+			defer db.Close()
+		}
 		os.Exit(1)
 	}()
 

--- a/cmd/mapper/mapper.go
+++ b/cmd/mapper/mapper.go
@@ -26,8 +26,7 @@ func main() {
 
 	conf, err := config.NewConfig("mapper")
 	if err != nil {
-		log.Error(err)
-		sigc <- syscall.SIGINT
+		log.Fatal(err)
 	}
 	mq, err := broker.NewMQ(conf.Broker)
 	if err != nil {

--- a/cmd/mapper/mapper.go
+++ b/cmd/mapper/mapper.go
@@ -5,6 +5,8 @@ package main
 import (
 	"encoding/json"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"sda-pipeline/internal/broker"
 	"sda-pipeline/internal/config"
@@ -20,27 +22,39 @@ type message struct {
 }
 
 func main() {
+	sigc := make(chan os.Signal, 5)
+
 	conf, err := config.NewConfig("mapper")
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		sigc <- syscall.SIGINT
 	}
 	mq, err := broker.NewMQ(conf.Broker)
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		sigc <- syscall.SIGINT
 	}
 	db, err := database.NewDB(conf.Database)
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		sigc <- syscall.SIGINT
 	}
 
-	defer mq.Channel.Close()
-	defer mq.Connection.Close()
-	defer db.Close()
+	signal.Notify(sigc, os.Interrupt, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+	go func() {
+		<-sigc
+		mq.Channel.Close()
+		mq.Connection.Close()
+		db.Close()
+		os.Exit(1)
+	}()
 
 	go func() {
 		connError := mq.ConnectionWatcher()
-		log.Error(connError)
-		os.Exit(1)
+		if connError != nil {
+			log.Errorf("Broker connError: %v", connError)
+			sigc <- syscall.SIGINT
+		}
 	}()
 
 	forever := make(chan bool)
@@ -51,7 +65,8 @@ func main() {
 	go func() {
 		messages, err := mq.GetMessages(conf.Broker.Queue)
 		if err != nil {
-			log.Fatalf("Failed to get message from mq (error: %v)", err)
+			log.Errorf("Failed to get message from mq (error: %v)", err)
+			sigc <- syscall.SIGINT
 		}
 		for delivered := range messages {
 			log.Debugf("received a message: %s", delivered.Body)

--- a/cmd/notify/notify.go
+++ b/cmd/notify/notify.go
@@ -37,8 +37,10 @@ func main() {
 	signal.Notify(sigc, os.Interrupt, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 	go func() {
 		<-sigc
-		mq.Channel.Close()
-		mq.Connection.Close()
+		if mq != nil {
+			defer mq.Channel.Close()
+			defer mq.Connection.Close()
+		}
 		os.Exit(1)
 	}()
 

--- a/cmd/notify/notify.go
+++ b/cmd/notify/notify.go
@@ -26,8 +26,7 @@ func main() {
 
 	conf, err := config.NewConfig("notify")
 	if err != nil {
-		log.Error(err)
-		sigc <- syscall.SIGINT
+		log.Fatal(err)
 	}
 	mq, err := broker.NewMQ(conf.Broker)
 	if err != nil {

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"sda-pipeline/internal/broker"
 	"sda-pipeline/internal/config"
@@ -45,39 +47,54 @@ type checksums struct {
 }
 
 func main() {
+	sigc := make(chan os.Signal, 5)
+
 	conf, err := config.NewConfig("verify")
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		sigc <- syscall.SIGINT
 	}
 	mq, err := broker.NewMQ(conf.Broker)
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		sigc <- syscall.SIGINT
 	}
 	db, err := database.NewDB(conf.Database)
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		sigc <- syscall.SIGINT
 	}
 	archive, err := storage.NewBackend(conf.Archive)
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		sigc <- syscall.SIGINT
 	}
 	inbox, err := storage.NewBackend(conf.Inbox)
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		sigc <- syscall.SIGINT
 	}
 	key, err := config.GetC4GHKey()
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		sigc <- syscall.SIGINT
 	}
 
-	defer mq.Channel.Close()
-	defer mq.Connection.Close()
-	defer db.Close()
+	signal.Notify(sigc, os.Interrupt, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+	go func() {
+		<-sigc
+		mq.Channel.Close()
+		mq.Connection.Close()
+		db.Close()
+		os.Exit(1)
+	}()
 
 	go func() {
 		connError := mq.ConnectionWatcher()
-		log.Error(connError)
-		os.Exit(1)
+		if connError != nil {
+			log.Errorf("Broker connError: %v", connError)
+			sigc <- syscall.SIGINT
+		}
 	}()
 
 	forever := make(chan bool)
@@ -87,8 +104,8 @@ func main() {
 	go func() {
 		messages, err := mq.GetMessages(conf.Broker.Queue)
 		if err != nil {
-			log.Fatalf("Failed to get messages (error: %v) ",
-				err)
+			log.Errorf("Failed to get messages (error: %v) ", err)
+			sigc <- syscall.SIGINT
 		}
 		for delivered := range messages {
 			var message message

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -47,60 +47,71 @@ type checksums struct {
 }
 
 func main() {
-	sigc := make(chan os.Signal, 5)
+	forever := make(chan bool, 1)
+	sigc := make(chan os.Signal, 1)
+	signal.Notify(sigc, os.Interrupt, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+
+	defer func() {
+		if r := recover(); r != nil {
+			log.Infoln("Recovered")
+		}
+	}()
+
+	go func() {
+		<-sigc
+		forever <- false
+	}()
 
 	conf, err := config.NewConfig("verify")
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		sigc <- syscall.SIGINT
+		panic(err)
 	}
 	mq, err := broker.NewMQ(conf.Broker)
 	if err != nil {
 		log.Error(err)
 		sigc <- syscall.SIGINT
+		panic(err)
 	}
+	defer mq.Channel.Close()
+	defer mq.Connection.Close()
+
 	db, err := database.NewDB(conf.Database)
 	if err != nil {
 		log.Error(err)
 		sigc <- syscall.SIGINT
+		panic(err)
 	}
+	defer db.Close()
+
 	archive, err := storage.NewBackend(conf.Archive)
 	if err != nil {
 		log.Error(err)
 		sigc <- syscall.SIGINT
+		panic(err)
 	}
 	inbox, err := storage.NewBackend(conf.Inbox)
 	if err != nil {
 		log.Error(err)
 		sigc <- syscall.SIGINT
+		panic(err)
 	}
 	key, err := config.GetC4GHKey()
 	if err != nil {
 		log.Error(err)
 		sigc <- syscall.SIGINT
+		panic(err)
 	}
-
-	signal.Notify(sigc, os.Interrupt, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
-	go func() {
-		<-sigc
-		if mq != nil {
-			defer mq.Channel.Close()
-			defer mq.Connection.Close()
-		}
-		if db != nil {
-			defer db.Close()
-		}
-		os.Exit(1)
-	}()
 
 	go func() {
 		connError := mq.ConnectionWatcher()
 		if connError != nil {
 			log.Errorf("Broker connError: %v", connError)
 			sigc <- syscall.SIGINT
+			panic(connError)
 		}
 	}()
-
-	forever := make(chan bool)
 
 	log.Info("starting verify service")
 
@@ -109,6 +120,7 @@ func main() {
 		if err != nil {
 			log.Errorf("Failed to get messages (error: %v) ", err)
 			sigc <- syscall.SIGINT
+			panic(err)
 		}
 		for delivered := range messages {
 			var message message

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -82,9 +82,13 @@ func main() {
 	signal.Notify(sigc, os.Interrupt, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 	go func() {
 		<-sigc
-		mq.Channel.Close()
-		mq.Connection.Close()
-		db.Close()
+		if mq != nil {
+			defer mq.Channel.Close()
+			defer mq.Connection.Close()
+		}
+		if db != nil {
+			defer db.Close()
+		}
 		os.Exit(1)
 	}()
 

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -51,8 +51,7 @@ func main() {
 
 	conf, err := config.NewConfig("verify")
 	if err != nil {
-		log.Error(err)
-		sigc <- syscall.SIGINT
+		log.Fatal(err)
 	}
 	mq, err := broker.NewMQ(conf.Broker)
 	if err != nil {

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -80,6 +80,12 @@ func (*mockChannel) IsClosed() bool {
 	return false
 }
 
+func (*mockChannel) NotifyClose(c chan *amqp.Error) chan *amqp.Error {
+	close(c)
+
+	return c
+}
+
 func TestGetMessages_Error(t *testing.T) {
 	b := AMQPBroker{}
 	c := mockChannel{}


### PR DESCRIPTION
* handle interrupt signals from the OS
* remove all `log.Fatal` to make sure we exit cleanly in all cases.
* linter fixes - return with no blank line before (nlreturn)