### PR TITLE
Update/sda mq

### DIFF
--- a/.github/integration/tests/common/10_trigger_failures.sh
+++ b/.github/integration/tests/common/10_trigger_failures.sh
@@ -50,7 +50,7 @@ sha256sum=$(sha256sum wrongly_encrypted.c4gh | cut -d' ' -f 1)
 
 curl --cacert certs/ca.pem  -vvv -u test:test 'https://localhost:15672/api/exchanges/test/sda/publish' \
      -H 'Content-Type: application/json;charset=UTF-8' \
-     --data-binary "$( echo '{
+     --data-binary "$(echo '{
     	                       "vhost":"test",
                                "name":"sda",
     	                       "properties":{
@@ -74,7 +74,7 @@ curl --cacert certs/ca.pem  -vvv -u test:test 'https://localhost:15672/api/excha
     	                                                            }
     	                                                           ]
     	                                  }"
-    	                      }' | sed -e "s/SHA256SUM/${sha256sum}/" -e "s/MD5SUM/${md5sum}/" )"
+    	                      }' | sed -e "s/SHA256SUM/${sha256sum}/" -e "s/MD5SUM/${md5sum}/" | tr -d '[:space:]' )"
 
 # Verify that message is moved to the error queue
 
@@ -84,7 +84,7 @@ check_move_to_error_queue "decryption failed"
 
 curl --cacert certs/ca.pem  -vvv -u test:test 'https://localhost:15672/api/exchanges/test/sda/publish' \
      -H 'Content-Type: application/json;charset=UTF-8' \
-     --data-binary '{
+     --data-binary "$(echo '{
     	                       "vhost":"test",
                                "name":"sda",
     	                       "properties":{
@@ -108,7 +108,7 @@ curl --cacert certs/ca.pem  -vvv -u test:test 'https://localhost:15672/api/excha
     	                                                            }
     	                                                           ]
     	                                  }"
-    	                      }'
+    	                      }' | tr -d '[:space:]' )"
 
 
 # Verify that message is moved to the error queue (takes a few mins).
@@ -191,7 +191,7 @@ curl --cacert certs/ca.pem  -vvv -u test:test 'https://localhost:15672/api/excha
     	                                                            }
     	                                                           ]
     	                                  }"
-    	                      }' | sed -e "s/SHA256SUM/${sha256sum}/" -e "s/MD5SUM/${md5sum}/" )"
+    	                      }' | sed -e "s/SHA256SUM/${sha256sum}/" -e "s/MD5SUM/${md5sum}/" | tr -d '[:space:]' )"
 
 # Verify that message is moved to the error queue.
 
@@ -228,7 +228,7 @@ curl --cacert certs/ca.pem  -vvv -u test:test 'https://localhost:15672/api/excha
     	                                                            }
     	                                                           ]
     	                                  }"
-    	                      }' | sed -e "s/SHA256SUM/${sha256sum}/" -e "s/MD5SUM/${md5sum}/" )"
+    	                      }' | sed -e "s/SHA256SUM/${sha256sum}/" -e "s/MD5SUM/${md5sum}/" | tr -d '[:space:]' )"
 
 # Verify that message is moved to the error queue.
 
@@ -269,7 +269,7 @@ curl --cacert certs/ca.pem  -vvv -u test:test 'https://localhost:15672/api/excha
     	                                                            }
     	                                                           ]
     	                                  }"
-    	                      }' | sed -e "s/SHA256SUM/${sha256sum}/" -e "s/MD5SUM/${md5sum}/" )"
+    	                      }' | sed -e "s/SHA256SUM/${sha256sum}/" -e "s/MD5SUM/${md5sum}/" | tr -d '[:space:]' )"
 
 RETRY_TIMES=0
 echo

--- a/.github/integration/tests/common/30_ingest_test.sh
+++ b/.github/integration/tests/common/30_ingest_test.sh
@@ -81,7 +81,7 @@ for file in dummy_data.c4gh largefile.c4gh; do
 								}
 							]
 						}"
-						}' | sed -e "s/FILENAME/$file/" -e "s/MD5SUM/${md5sum}/" -e "s/SHA256SUM/${sha256sum}/" -e "s/CORRID/$count/")"
+						}' | sed -e "s/FILENAME/$file/" -e "s/MD5SUM/${md5sum}/" -e "s/SHA256SUM/${sha256sum}/" -e "s/CORRID/$count/" | tr -d '[:space:]' )"
 
 	RETRY_TIMES=0
 	until docker logs ingest --since="$now" 2>&1 | grep "File marked as archived"; do
@@ -181,7 +181,7 @@ for file in dummy_data.c4gh largefile.c4gh; do
 								}
 							]
 						}"
-						}' | sed -e "s/FILENAME/$filepath/" -e "s/DECMD5SUM/${decmd5sum}/" -e "s/DECSHA256SUM/${decsha256sum}/" -e "s/ACCESSIONID/${access}/" -e "s/CORRID/$count/")"
+						}' | sed -e "s/FILENAME/$filepath/" -e "s/DECMD5SUM/${decmd5sum}/" -e "s/DECSHA256SUM/${decsha256sum}/" -e "s/ACCESSIONID/${access}/" -e "s/CORRID/$count/" | tr -d '[:space:]' )"
 
 	echo "Waiting for finalize/backup to complete"
 
@@ -274,7 +274,7 @@ for file in dummy_data.c4gh largefile.c4gh; do
 							\"type\":\"mapping\",
 							\"dataset_id\":\"DATASET\",
 							\"accession_ids\":[\"ACCESSIONID\"]}"
-						}' | sed -e "s/DATASET/$dataset/" -e "s/ACCESSIONID/$access/" -e "s/CORRID/$count/")"
+						}' | sed -e "s/DATASET/$dataset/" -e "s/ACCESSIONID/$access/" -e "s/CORRID/$count/" | tr -d '[:space:]' )"
 
 	RETRY_TIMES=0
 	dbcheck=''

--- a/.github/integration/tests/common/8_bad_messages.sh
+++ b/.github/integration/tests/common/8_bad_messages.sh
@@ -53,8 +53,7 @@ for routingkey in files ingest archived accessionIDs backup mappings; do
 						},
 						"routing_key":"'"$routingkey"'",
 						"payload_encoding":"string",
-						"payload":"{
-						I give you bad json!}"
+						"payload":"{I give you bad json!}"
 					}'
 
 check_move_to_error_queue "I give you bad json"

--- a/.github/integration/tests/s3notls/40_ingest_test_notls.sh
+++ b/.github/integration/tests/s3notls/40_ingest_test_notls.sh
@@ -72,7 +72,7 @@ for file in dummy_data.c4gh largefile.c4gh; do
 								}
 							]
 						}"
-						}' | sed -e "s/FILENAME/$file/" -e "s/MD5SUM/${md5sum}/" -e "s/SHA256SUM/${sha256sum}/" -e "s/CORRID/$count/")"
+						}' | sed -e "s/FILENAME/$file/" -e "s/MD5SUM/${md5sum}/" -e "s/SHA256SUM/${sha256sum}/" -e "s/CORRID/$count/" | tr -d '[:space:]' )"
 
 	RETRY_TIMES=0
 	until docker logs ingest --since="$now" 2>&1 | grep "File marked as archived"; do
@@ -172,7 +172,7 @@ for file in dummy_data.c4gh largefile.c4gh; do
 								}
 							]
 						}"
-						}' | sed -e "s/FILENAME/$filepath/" -e "s/DECMD5SUM/${decmd5sum}/" -e "s/DECSHA256SUM/${decsha256sum}/" -e "s/ACCESSIONID/${access}/" -e "s/CORRID/$count/")"
+						}' | sed -e "s/FILENAME/$filepath/" -e "s/DECMD5SUM/${decmd5sum}/" -e "s/DECSHA256SUM/${decsha256sum}/" -e "s/ACCESSIONID/${access}/" -e "s/CORRID/$count/" | tr -d '[:space:]' )"
 
 	echo "Waiting for finalize/backup to complete"
 
@@ -264,7 +264,7 @@ for file in dummy_data.c4gh largefile.c4gh; do
 							\"type\":\"mapping\",
 							\"dataset_id\":\"DATASET\",
 							\"accession_ids\":[\"ACCESSIONID\"]}"
-						}' | sed -e "s/DATASET/$dataset/" -e "s/ACCESSIONID/$access/" -e "s/CORRID/$count/")"
+						}' | sed -e "s/DATASET/$dataset/" -e "s/ACCESSIONID/$access/" -e "s/CORRID/$count/" | tr -d '[:space:]' )"
 
 	RETRY_TIMES=0
 	dbcheck=''

--- a/.github/integration/tests/s3notlsheader/40_ingest_test_notls.sh
+++ b/.github/integration/tests/s3notlsheader/40_ingest_test_notls.sh
@@ -72,7 +72,7 @@ for file in dummy_data.c4gh largefile.c4gh; do
 								}
 							]
 						}"
-						}' | sed -e "s/FILENAME/$file/" -e "s/MD5SUM/${md5sum}/" -e "s/SHA256SUM/${sha256sum}/" -e "s/CORRID/$count/")"
+						}' | sed -e "s/FILENAME/$file/" -e "s/MD5SUM/${md5sum}/" -e "s/SHA256SUM/${sha256sum}/" -e "s/CORRID/$count/" | tr -d '[:space:]' )"
 
 	RETRY_TIMES=0
 	until docker logs ingest --since="$now" 2>&1 | grep "File marked as archived"; do
@@ -172,7 +172,7 @@ for file in dummy_data.c4gh largefile.c4gh; do
 								}
 							]
 						}"
-						}' | sed -e "s/FILENAME/$filepath/" -e "s/DECMD5SUM/${decmd5sum}/" -e "s/DECSHA256SUM/${decsha256sum}/" -e "s/ACCESSIONID/${access}/" -e "s/CORRID/$count/")"
+						}' | sed -e "s/FILENAME/$filepath/" -e "s/DECMD5SUM/${decmd5sum}/" -e "s/DECSHA256SUM/${decsha256sum}/" -e "s/ACCESSIONID/${access}/" -e "s/CORRID/$count/" | tr -d '[:space:]' )"
 
 	echo "Waiting for finalize/backup to complete"
 
@@ -264,7 +264,7 @@ for file in dummy_data.c4gh largefile.c4gh; do
 							\"type\":\"mapping\",
 							\"dataset_id\":\"DATASET\",
 							\"accession_ids\":[\"ACCESSIONID\"]}"
-						}' | sed -e "s/DATASET/$dataset/" -e "s/ACCESSIONID/$access/" -e "s/CORRID/$count/")"
+						}' | sed -e "s/DATASET/$dataset/" -e "s/ACCESSIONID/$access/" -e "s/CORRID/$count/" | tr -d '[:space:]' )"
 
 	RETRY_TIMES=0
 	dbcheck=''

--- a/cmd/ingest/ingest.md
+++ b/cmd/ingest/ingest.md
@@ -82,7 +82,7 @@ Storage backend is defined by the `ARCHIVE_TYPE`, and `INBOX_TYPE` variables.
 Valid values for these options are `S3` or `POSIX`
 (Defaults to `POSIX` on unknown values).
 
-The value of these variables define what other varaibles are read.
+The value of these variables define what other variables are read.
 The same variables are available for all storage types, differing by prefix (`ARCHIVE_`, or  `INBOX_`)
 
 if `*_TYPE` is `S3` then the following variables are available:

--- a/cmd/verify/verify.md
+++ b/cmd/verify/verify.md
@@ -81,7 +81,7 @@ Storage backend is defined by the `ARCHIVE_TYPE`, and `INBOX_TYPE` variables.
 Valid values for these options are `S3` or `POSIX`
 (Defaults to `POSIX` on unknown values).
 
-The value of these variables define what other varaibles are read.
+The value of these variables define what other variables are read.
 The same variables are available for all storage types, differing by prefix (`ARCHIVE_`, or  `INBOX_`)
 
 if `*_TYPE` is `S3` then the following variables are available:

--- a/dev_utils/compose-no-tls.yml
+++ b/dev_utils/compose-no-tls.yml
@@ -19,7 +19,7 @@ services:
     volumes:
       - /tmp/data:/data
   mq:
-    image: neicnordic/sda-mq:v1.4.24
+    image: ghcr.io/neicnordic/sda-mq:v1.4.24
     container_name: mq
     environment:
       - MQ_USER=test

--- a/dev_utils/compose-no-tls.yml
+++ b/dev_utils/compose-no-tls.yml
@@ -19,18 +19,24 @@ services:
     volumes:
       - /tmp/data:/data
   mq:
-    image: neicnordic/sda-mq:v1.4.0
+    image: neicnordic/sda-mq:v1.4.24
     container_name: mq
     environment:
-     - MQ_USER=test
-     - MQ_PASSWORD_HASH=C5ufXbYlww6ZBcEqDUB04YdUptO81s+ozI3Ll5GCHTnv8NAm
-     - MQ_VHOST=test
-     - NOTLS=true
+      - MQ_USER=test
+      - MQ_PASSWORD_HASH=C5ufXbYlww6ZBcEqDUB04YdUptO81s+ozI3Ll5GCHTnv8NAm
+      - MQ_VHOST=test
+      - NOTLS=true
     ports:
       - "15672:15672"
       - "5672:5672"
     healthcheck:
-      test: [ "CMD", "bash", "-c", "rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms"]
+      test:
+        [
+          "CMD",
+          "bash",
+          "-c",
+          "rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms",
+        ]
       interval: 5s
       timeout: 20s
       retries: 3
@@ -206,6 +212,6 @@ services:
     volumes:
       - ./config-notls.yaml:/config.yaml
 volumes:
-     archive:
-     backup:
-     inbox:
+  archive:
+  backup:
+  inbox:

--- a/dev_utils/compose-sda.yml
+++ b/dev_utils/compose-sda.yml
@@ -43,15 +43,15 @@ services:
       - certs:/var/lib/postgresql/tls/
   mq:
     container_name: mq
-    image: ghcr.io/neicnordic/sda-mq:v1.4.0
+    image: ghcr.io/neicnordic/sda-mq:v1.4.24
     environment:
-     - MQ_SERVER_CERT=/etc/rabbitmq/ssl/mq.pem
-     - MQ_SERVER_KEY=/etc/rabbitmq/ssl/mq.key
-     - MQ_CA=/etc/rabbitmq/ssl/ca.pem
-     - MQ_USER=test
-     - MQ_PASSWORD_HASH=C5ufXbYlww6ZBcEqDUB04YdUptO81s+ozI3Ll5GCHTnv8NAm
-     - MQ_VHOST=test
-     - MQ_VERIFY=verify_none
+      - MQ_SERVER_CERT=/etc/rabbitmq/ssl/mq.pem
+      - MQ_SERVER_KEY=/etc/rabbitmq/ssl/mq.key
+      - MQ_CA=/etc/rabbitmq/ssl/ca.pem
+      - MQ_USER=test
+      - MQ_PASSWORD_HASH=C5ufXbYlww6ZBcEqDUB04YdUptO81s+ozI3Ll5GCHTnv8NAm
+      - MQ_VHOST=test
+      - MQ_VERIFY=verify_none
     ports:
       - "15672:15672"
       - "5672:5672"
@@ -61,7 +61,13 @@ services:
       - ./certs/mq.pem:/etc/rabbitmq/ssl/mq.pem
       - ./certs/mq-key.pem:/etc/rabbitmq/ssl/mq.key
     healthcheck:
-      test: [ "CMD", "bash", "-c", "rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms"]
+      test:
+        [
+          "CMD",
+          "bash",
+          "-c",
+          "rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms",
+        ]
       interval: 5s
       timeout: 20s
       retries: 3
@@ -215,7 +221,7 @@ services:
 
   sftp-server:
     build:
-        context: sftp-server
+      context: sftp-server
     hostname: sftp-serv
     depends_on:
       certfixer:
@@ -226,14 +232,14 @@ services:
       - SFTP_USER_PUB_KEY=/keys/sftp-key.pub
     container_name: sftp-server-local
     ports:
-        - "6222:22"
+      - "6222:22"
     volumes:
-        - /uploads:/uploads
-        - ./certs:/keys
+      - /uploads:/uploads
+      - ./certs:/keys
 
 volumes:
-     archive:
-     certs:
-     backup:
-     inbox:
-     uploads:
+  archive:
+  certs:
+  backup:
+  inbox:
+  uploads:

--- a/dev_utils/config.yaml
+++ b/dev_utils/config.yaml
@@ -55,7 +55,7 @@ broker:
   clientKey: "./dev_utils/certs/client-key.pem"
 # If the FQDN and hostname of the broker differ
 # serverName can be set to the SAN name in the certificate
-  #  serverName: ""
+#  serverName: ""
 
 c4gh:
   passphrase: "oaagCP1YgAZeEyl2eJAkHv9lkcWXWFgm"


### PR DESCRIPTION
- small sanity update to make sure `sda-mq` still works in integration tests
- standard format the yaml files
- curl requests payload it is not interpreted properly with spaces and after so we strip the space.