### PR TITLE
Update minio version in docker compose files

### DIFF
--- a/dev_utils/compose-no-tls.yml
+++ b/dev_utils/compose-no-tls.yml
@@ -19,7 +19,7 @@ services:
     volumes:
       - /tmp/data:/data
   mq:
-    image: ghcr.io/neicnordic/sda-mq:v1.4.24
+    image: ghcr.io/neicnordic/sda-mq:v1.4.25
     container_name: mq
     environment:
       - MQ_USER=test
@@ -41,19 +41,21 @@ services:
       timeout: 20s
       retries: 3
   s3:
-    command: server /data
+    command: server /data --console-address ":9001"
     container_name: s3
     environment:
-      - MINIO_ACCESS_KEY=access
-      - MINIO_SECRET_KEY=secretkey
+      - MINIO_ROOT_USER=access
+      - MINIO_ROOT_PASSWORD=secretkey
+      - MINIO_SERVER_URL=http://127.0.0.1:9000
     healthcheck:
       test: ["CMD", "curl", "-fq", "http://localhost:9000/minio/health/live"]
       interval: 5s
       timeout: 20s
       retries: 3
-    image: minio/minio:RELEASE.2021-11-24T23-19-33Z
+    image: minio/minio:RELEASE.2022-09-25T15-44-53Z
     ports:
       - "9000:9000"
+      - "9001:9001"
   createbucket:
     image: minio/mc
     depends_on:

--- a/dev_utils/compose-sda.yml
+++ b/dev_utils/compose-sda.yml
@@ -43,7 +43,7 @@ services:
       - certs:/var/lib/postgresql/tls/
   mq:
     container_name: mq
-    image: ghcr.io/neicnordic/sda-mq:v1.4.24
+    image: ghcr.io/neicnordic/sda-mq:v1.4.25
     environment:
       - MQ_SERVER_CERT=/etc/rabbitmq/ssl/mq.pem
       - MQ_SERVER_KEY=/etc/rabbitmq/ssl/mq.key
@@ -72,19 +72,21 @@ services:
       timeout: 20s
       retries: 3
   s3:
-    command: server /data
+    command: server /data --console-address ":9001"
     container_name: s3
     environment:
-      - MINIO_ACCESS_KEY=access
-      - MINIO_SECRET_KEY=secretkey
+      - MINIO_ROOT_USER=access
+      - MINIO_ROOT_PASSWORD=secretkey
+      - MINIO_SERVER_URL=https://127.0.0.1:9000
     healthcheck:
       test: ["CMD", "curl", "-fkq", "https://localhost:9000/minio/health/live"]
       interval: 5s
       timeout: 20s
       retries: 3
-    image: minio/minio:RELEASE.2020-06-03T22-13-49Z
+    image: minio/minio:RELEASE.2022-09-25T15-44-53Z
     ports:
       - "9000:9000"
+      - "9001:9001"
     volumes:
       - ./certs/ca.pem:/root/.minio/certs/CAs/public.crt
       - ./certs/s3.pem:/root/.minio/certs/public.crt


### PR DESCRIPTION
The minio versions on the docker compose files are very (around 2 years) old and it don't run locally (at least for me). The PR updates the versions of the minio instance and uses the new way of passing credentials.

The version used here has been tested in sda-dashboard