### PR TITLE
Handle channel closures

### DIFF
--- a/cmd/intercept/intercept.go
+++ b/cmd/intercept/intercept.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 
 	"sda-pipeline/internal/broker"
 	"sda-pipeline/internal/config"
@@ -22,6 +21,7 @@ const (
 )
 
 func main() {
+	forever := make(chan bool)
 	conf, err := config.NewConfig("intercept")
 	if err != nil {
 		log.Fatal(err)
@@ -37,10 +37,14 @@ func main() {
 	go func() {
 		connError := mq.ConnectionWatcher()
 		log.Error(connError)
-		os.Exit(1)
+		forever <- false
 	}()
 
-	forever := make(chan bool)
+	go func() {
+		connError := mq.ChannelWatcher()
+		log.Error(connError)
+		forever <- false
+	}()
 
 	log.Info("Starting intercept service")
 

--- a/cmd/mapper/mapper.go
+++ b/cmd/mapper/mapper.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"encoding/json"
-	"os"
 
 	"sda-pipeline/internal/broker"
 	"sda-pipeline/internal/config"
@@ -20,6 +19,7 @@ type message struct {
 }
 
 func main() {
+	forever := make(chan bool)
 	conf, err := config.NewConfig("mapper")
 	if err != nil {
 		log.Fatal(err)
@@ -40,10 +40,14 @@ func main() {
 	go func() {
 		connError := mq.ConnectionWatcher()
 		log.Error(connError)
-		os.Exit(1)
+		forever <- false
 	}()
 
-	forever := make(chan bool)
+	go func() {
+		connError := mq.ChannelWatcher()
+		log.Error(connError)
+		forever <- false
+	}()
 
 	log.Info("Starting mapper service")
 	var mappings message

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 
 	"sda-pipeline/internal/broker"
 	"sda-pipeline/internal/config"
@@ -45,6 +44,7 @@ type checksums struct {
 }
 
 func main() {
+	forever := make(chan bool)
 	conf, err := config.NewConfig("verify")
 	if err != nil {
 		log.Fatal(err)
@@ -77,10 +77,14 @@ func main() {
 	go func() {
 		connError := mq.ConnectionWatcher()
 		log.Error(connError)
-		os.Exit(1)
+		forever <- false
 	}()
 
-	forever := make(chan bool)
+	go func() {
+		connError := mq.ChannelWatcher()
+		log.Error(connError)
+		forever <- false
+	}()
 
 	log.Info("starting verify service")
 

--- a/dev_utils/compose-no-tls.yml
+++ b/dev_utils/compose-no-tls.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   db:
     command: server /data
@@ -13,13 +12,13 @@ services:
       interval: 5s
       timeout: 20s
       retries: 3
-    image: neicnordic/sda-db:v2.0.10
+    image: ghcr.io/neicnordic/sda-db:v2.1.3
     ports:
       - "5432:5432"
     volumes:
       - /tmp/data:/data
   mq:
-    image: ghcr.io/neicnordic/sda-mq:v1.4.25
+    image: ghcr.io/neicnordic/sda-mq:v1.4.30
     container_name: mq
     environment:
       - MQ_USER=test
@@ -59,7 +58,8 @@ services:
   createbucket:
     image: minio/mc
     depends_on:
-      - s3
+      s3:
+        condition: service_healthy
     entrypoint: >
       /bin/sh -c "
       sleep 10;
@@ -73,9 +73,10 @@ services:
     command: sda-ingest
     container_name: ingest
     depends_on:
-      - db
-      - mq
-      - s3
+      db:
+        condition: service_healthy
+      mq:
+        condition: service_healthy
     environment:
       - ARCHIVE_TYPE=s3
       - ARCHIVE_URL=http://s3
@@ -97,9 +98,10 @@ services:
     command: sda-verify
     container_name: verify
     depends_on:
-      - db
-      - mq
-      - s3
+      db:
+        condition: service_healthy
+      mq:
+        condition: service_healthy
     environment:
       - ARCHIVE_URL=http://s3
       - ARCHIVE_TYPE=s3
@@ -121,8 +123,10 @@ services:
     command: sda-finalize
     container_name: finalize
     depends_on:
-      - db
-      - mq
+      db:
+        condition: service_healthy
+      mq:
+        condition: service_healthy
     environment:
       - BROKER_EXCHANGE=sda
       - BROKER_HOST=mq
@@ -134,14 +138,15 @@ services:
     volumes:
       - ./config-notls.yaml:/config.yaml
       - ./:/dev_utils/
-    restart: always
+    # restart: always
   backup:
     command: sda-backup
     container_name: backup
     depends_on:
-      - db
-      - mq
-      - s3
+      db:
+        condition: service_healthy
+      mq:
+        condition: service_healthy
     environment:
       - ARCHIVE_TYPE=s3
       - ARCHIVE_URL=http://s3
@@ -165,8 +170,10 @@ services:
     command: sda-mapper
     container_name: mapper
     depends_on:
-      - db
-      - mq
+      db:
+        condition: service_healthy
+      mq:
+        condition: service_healthy
     environment:
       - BROKER_EXCHANGE=sda
       - BROKER_HOST=mq
@@ -183,7 +190,8 @@ services:
   interceptor:
     command: sda-intercept
     depends_on:
-      - mq
+      mq:
+        condition: service_healthy
     environment:
       - BROKER_EXCHANGE=sda
       - BROKER_HOST=mq
@@ -199,8 +207,10 @@ services:
     command: sda-api
     container_name: api
     depends_on:
-      - db
-      - mq
+      db:
+        condition: service_healthy
+      mq:
+        condition: service_healthy
     environment:
       - BROKER_EXCHANGE=sda
       - BROKER_HOST=mq

--- a/dev_utils/compose-sda.yml
+++ b/dev_utils/compose-sda.yml
@@ -1,4 +1,3 @@
-version: "2.4"
 services:
   certfixer:
     command:
@@ -21,7 +20,8 @@ services:
     command: server /data
     container_name: db
     depends_on:
-      - certfixer
+      certfixer:
+        condition: service_completed_successfully
     environment:
       - DB_LEGA_IN_PASSWORD=lega_in
       - DB_LEGA_OUT_PASSWORD=lega_out
@@ -35,7 +35,7 @@ services:
       interval: 5s
       timeout: 20s
       retries: 3
-    image: ghcr.io/neicnordic/sda-db:v2.0.10
+    image: ghcr.io/neicnordic/sda-db:v2.1.3
     ports:
       - "5432:5432"
     volumes:
@@ -43,7 +43,10 @@ services:
       - certs:/var/lib/postgresql/tls/
   mq:
     container_name: mq
-    image: ghcr.io/neicnordic/sda-mq:v1.4.25
+    depends_on:
+      certfixer:
+        condition: service_completed_successfully
+    image: ghcr.io/neicnordic/sda-mq:v1.4.30
     environment:
       - MQ_SERVER_CERT=/etc/rabbitmq/ssl/mq.pem
       - MQ_SERVER_KEY=/etc/rabbitmq/ssl/mq.key
@@ -74,6 +77,9 @@ services:
   s3:
     command: server /data --console-address ":9001"
     container_name: s3
+    depends_on:
+      certfixer:
+        condition: service_completed_successfully
     environment:
       - MINIO_ROOT_USER=access
       - MINIO_ROOT_PASSWORD=secretkey
@@ -95,7 +101,10 @@ services:
     container_name: buckets
     image: minio/mc
     depends_on:
-      - s3
+      certfixer:
+        condition: service_completed_successfully
+      s3:
+        condition: service_healthy
     entrypoint: >
       /bin/sh -c "
       sleep 10;
@@ -111,9 +120,12 @@ services:
     command: sda-ingest
     container_name: ingest
     depends_on:
-      - certfixer
-      - mq
-      - db
+      certfixer:
+        condition: service_completed_successfully
+      db:
+        condition: service_healthy
+      mq:
+        condition: service_healthy
     env_file: ./env.ingest
     image: neicnordic/sda-pipeline:latest
     volumes:
@@ -128,9 +140,12 @@ services:
     command: sda-verify
     container_name: verify
     depends_on:
-      - certfixer
-      - mq
-      - db
+      certfixer:
+        condition: service_completed_successfully
+      db:
+        condition: service_healthy
+      mq:
+        condition: service_healthy
     env_file: ./env.verify
     image: neicnordic/sda-pipeline:latest
     volumes:
@@ -145,9 +160,12 @@ services:
     command: sda-finalize
     container_name: finalize
     depends_on:
-      - certfixer
-      - mq
-      - db
+      certfixer:
+        condition: service_completed_successfully
+      db:
+        condition: service_healthy
+      mq:
+        condition: service_healthy
     env_file: ./env.finalize
     image: neicnordic/sda-pipeline:latest
     volumes:
@@ -160,10 +178,12 @@ services:
     command: sda-backup
     container_name: backup
     depends_on:
-      - certfixer
-      - mq
-      - db
-      - sftp-server
+      certfixer:
+        condition: service_completed_successfully
+      db:
+        condition: service_healthy
+      mq:
+        condition: service_healthy
     env_file: ./env.backup
     image: neicnordic/sda-pipeline:latest
     volumes:
@@ -179,9 +199,12 @@ services:
     command: sda-mapper
     container_name: mapper
     depends_on:
-      - certfixer
-      - mq
-      - db
+      certfixer:
+        condition: service_completed_successfully
+      db:
+        condition: service_healthy
+      mq:
+        condition: service_healthy
     env_file: ./env.mapper
     image: neicnordic/sda-pipeline:latest
     volumes:
@@ -208,9 +231,12 @@ services:
     command: sda-api
     container_name: api
     depends_on:
-      - certfixer
-      - db
-      - mq
+      certfixer:
+        condition: service_completed_successfully
+      db:
+        condition: service_healthy
+      mq:
+        condition: service_healthy
     env_file: ./env.api
     image: neicnordic/sda-pipeline:latest
     ports:

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -22,6 +22,7 @@ var logFatalf = log.Fatalf
 type AMQPChannel interface {
 	Consume(queue, consumer string, autoAck, exclusive, noLocal, noWait bool, args amqp.Table) (<-chan amqp.Delivery, error)
 	Confirm(noWait bool) error
+	NotifyClose(c chan *amqp.Error) chan *amqp.Error
 	NotifyPublish(confirm chan amqp.Confirmation) chan amqp.Confirmation
 	Publish(exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error
 	Close() error
@@ -241,6 +242,12 @@ func TLSConfigBroker(config MQConf) (*tls.Config, error) {
 // ConnectionWatcher listens to events from the server
 func (broker *AMQPBroker) ConnectionWatcher() *amqp.Error {
 	amqpError := <-broker.Connection.NotifyClose(make(chan *amqp.Error))
+
+	return amqpError
+}
+
+func (broker *AMQPBroker) ChannelWatcher() *amqp.Error {
+	amqpError := <-broker.Channel.NotifyClose(make(chan *amqp.Error))
 
 	return amqpError
 }

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -51,6 +51,12 @@ func (c *mockChannel) Confirm(noWait bool) error {
 	return nil
 }
 
+func (c *mockChannel) NotifyClose(ch chan *amqp.Error) chan *amqp.Error {
+	close(ch)
+
+	return ch
+}
+
 func (c *mockChannel) NotifyPublish(confirm chan amqp.Confirmation) chan amqp.Confirmation {
 
 	c.confirmChannel = confirm

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -145,8 +145,6 @@ func TestBuildMqURI(t *testing.T) {
 
 func TestNewMQ(t *testing.T) {
 	noSSLPort := 5555 // + int(rand.Float64()*32768)
-	sslPort := noSSLPort + 1
-
 	s := startServer(t, noSSLPort)
 
 	noSslConf := tMqconf
@@ -167,25 +165,6 @@ func TestNewMQ(t *testing.T) {
 	errret = CatchNewMQPanic(t, noSslConf)
 	assert.NotNil(t, errret, "NewMQ did fail as expected")
 	s.Close()
-
-	sslConf := tMqconf
-	sslConf.Ssl = true
-	sslConf.VerifyPeer = false
-	sslConf.Port = sslPort
-	sslConf.ServerName = sslConf.Host
-
-	serverTLSConfig := tlsServerConfig()
-	serverTLSConfig.ClientAuth = tls.NoClientCert
-
-	ss := startTLSServer(t, sslPort, serverTLSConfig)
-
-	go handleOneConnection(ss.Sessions, false, false)
-
-	b, _ = NewMQ(sslConf)
-	assert.NotNil(t, b, "NewMQ with ssl did not return a broker")
-
-	ss.Close()
-
 }
 
 func CatchNewMQPanic(t *testing.T, conf MQConf) (err error) {
@@ -233,6 +212,30 @@ func TestNewMQConn_Error(t *testing.T) {
 	}
 }
 
+func TestNewMQTLS(t *testing.T) {
+	if _, err := os.Stat("../../dev_utils/certs/ca.pem"); err != nil {
+		t.Skip("skip test since certificates are not present")
+	}
+	sslPort := 5556
+	sslConf := tMqconf
+	sslConf.Ssl = true
+	sslConf.VerifyPeer = false
+	sslConf.Port = sslPort
+	sslConf.ServerName = sslConf.Host
+
+	serverTLSConfig := tlsServerConfig()
+	serverTLSConfig.ClientAuth = tls.NoClientCert
+
+	ss := startTLSServer(t, sslPort, serverTLSConfig)
+	go handleOneConnection(ss.Sessions, false, false)
+
+	b, e := NewMQ(sslConf)
+	assert.Nil(t, e, "Unwanted Error")
+	assert.NotNil(t, b, "NewMQ with ssl did not return a broker")
+
+	ss.Close()
+}
+
 func CatchTLSConfigBrokerPanic(b MQConf) (cfg *tls.Config, err error) {
 	defer func() {
 		r := recover()
@@ -248,6 +251,9 @@ func CatchTLSConfigBrokerPanic(b MQConf) (cfg *tls.Config, err error) {
 
 func TestTLSConfigBroker(t *testing.T) {
 	tlsConfig, err := TLSConfigBroker(tMqconf)
+	if err != nil && strings.Contains(err.Error(), "no such file or directory") {
+		t.Skip("skip test since certificates are not present")
+	}
 	assert.NoError(t, err, "Unexpected error")
 	assert.NotZero(t, tlsConfig.Certificates, "Expected warnings were missing")
 	assert.EqualValues(t, tlsConfig.ServerName, "servername")


### PR DESCRIPTION
These seems to be the smallest changed needed in order to be able to handle a closed channel.

Using the library version of the Channel definition `*amqp.Channel` will require a much larger rewrite, specially of our tests.

Testing this is not straight forward as a channel can only be closed form the client side with the exemption of a channel time out event that happens after 30 min of inactivity.
To force a channel closure these actions needs to be taken:
* start MQ, DB and finalize
* pause the DB
* send a correct message to finalize
* wait for 30 min


closes #412 