### PR TITLE
Allow for setting message prefetch number

### DIFF
--- a/cmd/backup/backup.md
+++ b/cmd/backup/backup.md
@@ -48,6 +48,8 @@ These settings control how backup connects to the RabbitMQ message broker.
 
  - `BROKER_PASSWORD`: password to connect to rabbitmq
 
+ - `BROKER_PREFETCHCOUNT`: Number of messagfes to pull from the message server at the time (default to 2)
+
 ### PostgreSQL Database settings:
 
  - `DB_HOST`: hostname for the postgresql database

--- a/cmd/finalize/finalize.md
+++ b/cmd/finalize/finalize.md
@@ -36,6 +36,8 @@ These settings control how finalize connects to the RabbitMQ message broker.
 
  - `BROKER_PASSWORD`: password to connect to rabbitmq
 
+ - `BROKER_PREFETCHCOUNT`: Number of messagfes to pull from the message server at the time (default to 2)
+
 ### PostgreSQL Database settings:
 
  - `DB_HOST`: hostname for the postgresql database

--- a/cmd/ingest/ingest.md
+++ b/cmd/ingest/ingest.md
@@ -43,6 +43,8 @@ These settings control how ingest connects to the RabbitMQ message broker.
 
  - `BROKER_PASSWORD`: password to connect to rabbitmq
 
+ - `BROKER_PREFETCHCOUNT`: Number of messagfes to pull from the message server at the time (default to 2)
+
 ### PostgreSQL Database settings:
 
  - `DB_HOST`: hostname for the postgresql database

--- a/cmd/mapper/mapper.md
+++ b/cmd/mapper/mapper.md
@@ -33,6 +33,8 @@ These settings control how mapper connects to the RabbitMQ message broker.
 
  - `BROKER_PASSWORD`: password to connect to rabbitmq
 
+ - `BROKER_PREFETCHCOUNT`: Number of messagfes to pull from the message server at the time (default to 2)
+
 ### PostgreSQL Database settings:
 
  - `DB_HOST`: hostname for the postgresql database

--- a/cmd/verify/verify.md
+++ b/cmd/verify/verify.md
@@ -42,6 +42,8 @@ These settings control how verify connects to the RabbitMQ message broker.
 
  - `BROKER_PASSWORD`: password to connect to rabbitmq
 
+ - `BROKER_PREFETCHCOUNT`: Number of messagfes to pull from the message server at the time (default to 2)
+
 ### PostgreSQL Database settings:
 
  - `DB_HOST`: hostname for the postgresql database

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -57,6 +57,7 @@ type MQConf struct {
 	ServerName         string
 	Durable            bool
 	SchemasPath        string
+	PrefetchCount      int
 }
 
 // InfoError struct for sending detailed error messages to analysis.
@@ -115,6 +116,11 @@ func NewMQ(config MQConf) (*AMQPBroker, error) {
 		fmt.Printf("channel could not be put into confirm mode: %s", e)
 
 		return nil, fmt.Errorf("channel could not be put into confirm mode: %s", e)
+	}
+
+	// limit the number of messages retrieved from the queue
+	if err := Channel.Qos(config.PrefetchCount, 0, true); err != nil {
+		log.Errorf("failed to set Channel QoS to %d, reason: %v", config.PrefetchCount, err)
 	}
 
 	confirms := Channel.NotifyPublish(make(chan amqp.Confirmation, 1))

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -117,7 +117,8 @@ func TestSendMessage(t *testing.T) {
 
 }
 
-var tMqconf = MQConf{"127.0.0.1",
+var tMqconf = MQConf{
+	"127.0.0.1",
 	6565,
 	"user",
 	"password",
@@ -134,7 +135,9 @@ var tMqconf = MQConf{"127.0.0.1",
 	"../../dev_utils/certs/client-key.pem",
 	"servername",
 	true,
-	"file://../../schemas/federated/"}
+	"file://../../schemas/federated/",
+	2,
+}
 
 func TestBuildMqURI(t *testing.T) {
 	amqps := buildMQURI("localhost", "user", "pass", "/vhost", 5555, true)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -413,6 +413,11 @@ func (c *Config) configBroker() error {
 		broker.CACert = viper.GetString("broker.cacert")
 	}
 
+	broker.PrefetchCount = 2
+	if viper.IsSet("broker.prefetchCount") {
+		broker.PrefetchCount = viper.GetInt("broker.prefetchCount")
+	}
+
 	c.Broker = broker
 
 	return nil


### PR DESCRIPTION
This fixes an issue when the queue contains to many messages and the time for processing each message takes so long that acking a message not being worked on times out after 30min.

- default number of messages to retrieve from the server is set to 2
- setting the prefetch number to 1 will allow for a true round-robin situation with multiple workers

Fixes #575 