### PR TITLE
Feature/new dataset messages #minor

### DIFF
--- a/.github/integration/tests/posix/50_check_files.sh
+++ b/.github/integration/tests/posix/50_check_files.sh
@@ -14,8 +14,8 @@ function db_query() {
 echo "Checking archive files in backup"
 
 # Earlier tests verify that the file is in the database correctly
-
-accessids=$(db_query "SELECT stable_id FROM local_ega.files where status='READY';")
+# even though the files are disabled we can still get them from the db
+accessids=$(db_query "SELECT stable_id FROM local_ega.files where status='DISABLED';")
 
 if [ -z "$accessids" ]; then
 	echo "Failed to get accession ids"

--- a/.github/integration/tests/posixheader/50_check_files.sh
+++ b/.github/integration/tests/posixheader/50_check_files.sh
@@ -14,8 +14,8 @@ function db_query() {
 echo "Checking archive files in backup"
 
 # Earlier tests verify that the file is in the database correctly
-
-accessids=$(db_query "SELECT stable_id FROM local_ega.files where status='READY';")
+# even though the files are disabled we can still get them from the db
+accessids=$(db_query "SELECT stable_id FROM local_ega.files where status='DISABLED';")
 
 if [ -z "$accessids" ]; then
 	echo "Failed to get accession ids"

--- a/.github/integration/tests/s3/50_check_files.sh
+++ b/.github/integration/tests/s3/50_check_files.sh
@@ -15,7 +15,7 @@ echo "Checking archive files in s3"
 
 # Earlier tests verify that the file is in the database correctly
 
-accessids=$(db_query "SELECT stable_id FROM local_ega.files where status='READY';")
+accessids=$(db_query "SELECT stable_id FROM local_ega.files where status='DISABLED';")
 
 if [ -z "$accessids" ]; then
 	echo "Failed to get accession ids"

--- a/.github/integration/tests/s3header/50_check_files.sh
+++ b/.github/integration/tests/s3header/50_check_files.sh
@@ -14,8 +14,8 @@ function db_query() {
 echo "Checking archive files in s3"
 
 # Earlier tests verify that the file is in the database correctly
-
-accessids=$(db_query "SELECT stable_id FROM local_ega.files where status='READY';")
+# even though the files are disabled we can still get them from the db
+accessids=$(db_query "SELECT stable_id FROM local_ega.files where status='DISABLED';")
 
 if [ -z "$accessids" ]; then
 	echo "Failed to get accession ids"

--- a/.github/integration/tests/s3notls/40_ingest_test_notls.sh
+++ b/.github/integration/tests/s3notls/40_ingest_test_notls.sh
@@ -44,6 +44,8 @@ for file in dummy_data.c4gh largefile.c4gh; do
 	decryptedfilesize=$(sed -ne 's/^\([0-9][0-9]*\) bytes (.*) copied, .*$/\1/p' "$dcf")
 	rm -f "$dcf"
 
+	correlation_id=$(uuidgen -t)
+
 	curl -vvv -u test:test 'http://localhost:15672/api/exchanges/test/sda/publish' \
 		-H 'Content-Type: application/json;charset=UTF-8' \
 		--data-binary "$(echo '{
@@ -72,7 +74,7 @@ for file in dummy_data.c4gh largefile.c4gh; do
 								}
 							]
 						}"
-						}' | sed -e "s/FILENAME/$file/" -e "s/MD5SUM/${md5sum}/" -e "s/SHA256SUM/${sha256sum}/" -e "s/CORRID/$count/" | tr -d '[:space:]' )"
+						}' | sed -e "s/FILENAME/$file/" -e "s/MD5SUM/${md5sum}/" -e "s/SHA256SUM/${sha256sum}/" -e "s/CORRID/$correlation_id/" | tr -d '[:space:]' )"
 
 	RETRY_TIMES=0
 	until docker logs ingest --since="$now" 2>&1 | grep "File marked as archived"; do
@@ -172,7 +174,7 @@ for file in dummy_data.c4gh largefile.c4gh; do
 								}
 							]
 						}"
-						}' | sed -e "s/FILENAME/$filepath/" -e "s/DECMD5SUM/${decmd5sum}/" -e "s/DECSHA256SUM/${decsha256sum}/" -e "s/ACCESSIONID/${access}/" -e "s/CORRID/$count/" | tr -d '[:space:]' )"
+						}' | sed -e "s/FILENAME/$filepath/" -e "s/DECMD5SUM/${decmd5sum}/" -e "s/DECSHA256SUM/${decsha256sum}/" -e "s/ACCESSIONID/${access}/" -e "s/CORRID/$correlation_id/" | tr -d '[:space:]' )"
 
 	echo "Waiting for finalize/backup to complete"
 
@@ -228,24 +230,6 @@ for file in dummy_data.c4gh largefile.c4gh; do
 
 	dataset=$(printf "EGAD%011d" "$count")
 
-	# Check that it showed up in the database as well
-
-	RETRY_TIMES=0
-	statusindb=''
-
-	until [ -n "$statusindb" ]; do
-		statusindb=$(docker run --rm --name client --network dev_utils_default \
-			neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
-			-t -A -c "SELECT id FROM local_ega.files where stable_id='$access' AND status='READY';")
-		sleep 3
-		RETRY_TIMES=$((RETRY_TIMES + 1))
-
-		if [ "$RETRY_TIMES" -eq 150 ]; then
-			echo "Timed out waiting correct status in database, aborting"
-			exit 1
-		fi
-	done
-
 	# Map dataset ids
 	curl -vvv -u test:test 'http://localhost:15672/api/exchanges/test/sda/publish' \
 		-H 'Content-Type: application/json;charset=UTF-8' \
@@ -264,7 +248,7 @@ for file in dummy_data.c4gh largefile.c4gh; do
 							\"type\":\"mapping\",
 							\"dataset_id\":\"DATASET\",
 							\"accession_ids\":[\"ACCESSIONID\"]}"
-						}' | sed -e "s/DATASET/$dataset/" -e "s/ACCESSIONID/$access/" -e "s/CORRID/$count/" | tr -d '[:space:]' )"
+						}' | sed -e "s/DATASET/$dataset/" -e "s/ACCESSIONID/$access/" -e "s/CORRID/$correlation_id/" | tr -d '[:space:]' )"
 
 	RETRY_TIMES=0
 	dbcheck=''
@@ -323,6 +307,43 @@ for file in dummy_data.c4gh largefile.c4gh; do
 
 				exit 1
 			fi
+		fi
+	done
+
+	# Release dataset ids
+	curl -vvv -u test:test 'http://localhost:15672/api/exchanges/test/sda/publish' \
+		-H 'Content-Type: application/json;charset=UTF-8' \
+		--data-binary "$(echo '{
+						"vhost":"test",
+						"name":"sda",
+						"properties":{
+							"delivery_mode":2,
+							"correlation_id":"CORRID",
+							"content_encoding":"UTF-8",
+							"content_type":"application/json"
+						},
+						"routing_key":"files",
+						"payload_encoding":"string",
+						"payload":"{
+							\"type\":\"release\",
+							\"dataset_id\":\"DATASET\"}"
+						}' | sed -e "s/DATASET/$dataset/" -e "s/CORRID/$correlation_id/" | tr -d '[:space:]' )"
+
+	# Check that it showed up in the database as well
+
+	RETRY_TIMES=0
+	statusindb=''
+
+	until [ -n "$statusindb" ]; do
+		statusindb=$(docker run --rm --name client --network dev_utils_default \
+			neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
+			-t -A -c "SELECT id FROM local_ega.files where stable_id='$access' AND status='READY';")
+		sleep 3
+		RETRY_TIMES=$((RETRY_TIMES + 1))
+
+		if [ "$RETRY_TIMES" -eq 150 ]; then
+			echo "Timed out waiting correct status in database, aborting"
+			exit 1
 		fi
 	done
 

--- a/.github/integration/tests/s3notlsheader/40_ingest_test_notls.sh
+++ b/.github/integration/tests/s3notlsheader/40_ingest_test_notls.sh
@@ -44,6 +44,8 @@ for file in dummy_data.c4gh largefile.c4gh; do
 	decryptedfilesize=$(sed -ne 's/^\([0-9][0-9]*\) bytes (.*) copied, .*$/\1/p' "$dcf")
 	rm -f "$dcf"
 
+	correlation_id=$(uuidgen -t)
+
 	curl -vvv -u test:test 'http://localhost:15672/api/exchanges/test/sda/publish' \
 		-H 'Content-Type: application/json;charset=UTF-8' \
 		--data-binary "$(echo '{
@@ -72,7 +74,7 @@ for file in dummy_data.c4gh largefile.c4gh; do
 								}
 							]
 						}"
-						}' | sed -e "s/FILENAME/$file/" -e "s/MD5SUM/${md5sum}/" -e "s/SHA256SUM/${sha256sum}/" -e "s/CORRID/$count/" | tr -d '[:space:]' )"
+						}' | sed -e "s/FILENAME/$file/" -e "s/MD5SUM/${md5sum}/" -e "s/SHA256SUM/${sha256sum}/" -e "s/CORRID/$correlation_id/" | tr -d '[:space:]' )"
 
 	RETRY_TIMES=0
 	until docker logs ingest --since="$now" 2>&1 | grep "File marked as archived"; do
@@ -172,7 +174,7 @@ for file in dummy_data.c4gh largefile.c4gh; do
 								}
 							]
 						}"
-						}' | sed -e "s/FILENAME/$filepath/" -e "s/DECMD5SUM/${decmd5sum}/" -e "s/DECSHA256SUM/${decsha256sum}/" -e "s/ACCESSIONID/${access}/" -e "s/CORRID/$count/" | tr -d '[:space:]' )"
+						}' | sed -e "s/FILENAME/$filepath/" -e "s/DECMD5SUM/${decmd5sum}/" -e "s/DECSHA256SUM/${decsha256sum}/" -e "s/ACCESSIONID/${access}/" -e "s/CORRID/$correlation_id/" | tr -d '[:space:]' )"
 
 	echo "Waiting for finalize/backup to complete"
 
@@ -228,24 +230,6 @@ for file in dummy_data.c4gh largefile.c4gh; do
 
 	dataset=$(printf "EGAD%011d" "$count")
 
-	# Check that it showed up in the database as well
-
-	RETRY_TIMES=0
-	statusindb=''
-
-	until [ -n "$statusindb" ]; do
-		statusindb=$(docker run --rm --name client --network dev_utils_default \
-			neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
-			-t -A -c "SELECT id FROM local_ega.files where stable_id='$access' AND status='READY';")
-		sleep 3
-		RETRY_TIMES=$((RETRY_TIMES + 1))
-
-		if [ "$RETRY_TIMES" -eq 150 ]; then
-			echo "Timed out waiting correct status in database, aborting"
-			exit 1
-		fi
-	done
-
 	# Map dataset ids
 	curl -vvv -u test:test 'http://localhost:15672/api/exchanges/test/sda/publish' \
 		-H 'Content-Type: application/json;charset=UTF-8' \
@@ -264,7 +248,7 @@ for file in dummy_data.c4gh largefile.c4gh; do
 							\"type\":\"mapping\",
 							\"dataset_id\":\"DATASET\",
 							\"accession_ids\":[\"ACCESSIONID\"]}"
-						}' | sed -e "s/DATASET/$dataset/" -e "s/ACCESSIONID/$access/" -e "s/CORRID/$count/" | tr -d '[:space:]' )"
+						}' | sed -e "s/DATASET/$dataset/" -e "s/ACCESSIONID/$access/" -e "s/CORRID/$correlation_id/" | tr -d '[:space:]' )"
 
 	RETRY_TIMES=0
 	dbcheck=''
@@ -323,6 +307,43 @@ for file in dummy_data.c4gh largefile.c4gh; do
 
 				exit 1
 			fi
+		fi
+	done
+
+	# Release dataset ids
+	curl -vvv -u test:test 'http://localhost:15672/api/exchanges/test/sda/publish' \
+		-H 'Content-Type: application/json;charset=UTF-8' \
+		--data-binary "$(echo '{
+						"vhost":"test",
+						"name":"sda",
+						"properties":{
+							"delivery_mode":2,
+							"correlation_id":"CORRID",
+							"content_encoding":"UTF-8",
+							"content_type":"application/json"
+						},
+						"routing_key":"files",
+						"payload_encoding":"string",
+						"payload":"{
+							\"type\":\"release\",
+							\"dataset_id\":\"DATASET\"}"
+						}' | sed -e "s/DATASET/$dataset/" -e "s/CORRID/$correlation_id/" | tr -d '[:space:]' )"
+
+	# Check that it showed up in the database as well
+
+	RETRY_TIMES=0
+	statusindb=''
+
+	until [ -n "$statusindb" ]; do
+		statusindb=$(docker run --rm --name client --network dev_utils_default \
+			neicnordic/pg-client:latest postgresql://lega_in:lega_in@db:5432/lega \
+			-t -A -c "SELECT id FROM local_ega.files where stable_id='$access' AND status='READY';")
+		sleep 3
+		RETRY_TIMES=$((RETRY_TIMES + 1))
+
+		if [ "$RETRY_TIMES" -eq 150 ]; then
+			echo "Timed out waiting correct status in database, aborting"
+			exit 1
 		fi
 	done
 

--- a/.github/integration/tests/sftp/50_check_files.sh
+++ b/.github/integration/tests/sftp/50_check_files.sh
@@ -14,8 +14,9 @@ function db_query() {
 echo "Checking archive files in s3"
 
 # Earlier tests verify that the file is in the database correctly
+# even though the files are disabled we can still get them from the db
 
-accessids=$(db_query "SELECT stable_id FROM local_ega.files where status='READY';")
+accessids=$(db_query "SELECT stable_id FROM local_ega.files where status='DISABLED';")
 
 if [ -z "$accessids" ]; then
 	echo "Failed to get accession ids"

--- a/.github/integration/tests/sftpheader/50_check_files.sh
+++ b/.github/integration/tests/sftpheader/50_check_files.sh
@@ -14,8 +14,8 @@ function db_query() {
 echo "Checking archive files in s3"
 
 # Earlier tests verify that the file is in the database correctly
-
-accessids=$(db_query "SELECT stable_id FROM local_ega.files where status='READY';")
+# even though the files are disabled we can still get them from the db
+accessids=$(db_query "SELECT stable_id FROM local_ega.files where status='DISABLED';")
 
 if [ -z "$accessids" ]; then
 	echo "Failed to get accession ids"

--- a/cmd/backup/backup.md
+++ b/cmd/backup/backup.md
@@ -48,7 +48,7 @@ These settings control how backup connects to the RabbitMQ message broker.
 
  - `BROKER_PASSWORD`: password to connect to rabbitmq
 
- - `BROKER_PREFETCHCOUNT`: Number of messagfes to pull from the message server at the time (default to 2)
+ - `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to 2)
 
 ### PostgreSQL Database settings:
 

--- a/cmd/finalize/finalize.go
+++ b/cmd/finalize/finalize.go
@@ -162,7 +162,7 @@ func main() {
 					err)
 
 				if e := delivered.Nack(false, true); e != nil {
-					log.Errorf("Failed to NAck because of MarkReady failed "+
+					log.Errorf("Failed to NAck because of checking accession id exists failed "+
 						"(corr-id: %s, "+
 						"filepath: %s, "+
 						"user: %s, "+
@@ -215,7 +215,7 @@ func main() {
 
 				// Nack message so the server gets notified that something is wrong and don't requeue the message
 				if e := delivered.Nack(false, false); e != nil {
-					log.Errorf("Failed to NAck because of MarkReady failed "+
+					log.Errorf("Failed to NAck because of sending error failed "+
 						"(corr-id: %s, "+
 						"filepath: %s, "+
 						"user: %s, "+
@@ -234,8 +234,8 @@ func main() {
 
 			}
 
-			if err := db.MarkReady(message.AccessionID, message.User, message.Filepath, checksumSha256); err != nil {
-				log.Errorf("MarkReady failed "+
+			if err := db.SetAccessionID(message.AccessionID, message.User, message.Filepath, checksumSha256); err != nil {
+				log.Errorf("SetAccessionID failed "+
 					"(corr-id: %s, "+
 					"filepath: %s, "+
 					"user: %s, "+
@@ -249,7 +249,7 @@ func main() {
 					err)
 
 				if e := delivered.Nack(false, true); e != nil {
-					log.Errorf("Failed to NAck because of MarkReady failed "+
+					log.Errorf("Failed to NAck because of SetAccessionID failed "+
 						"(corr-id: %s, "+
 						"filepath: %s, "+
 						"user: %s, "+
@@ -278,8 +278,6 @@ func main() {
 				message.User,
 				message.AccessionID,
 				message.DecryptedChecksums)
-
-			log.Debug("Mark ready")
 
 			if err := mq.SendMessage(delivered.CorrelationId, conf.Broker.Exchange, conf.Broker.RoutingKey, conf.Broker.Durable, completeMsg); err != nil {
 				// TODO fix resend mechanism

--- a/cmd/finalize/finalize.md
+++ b/cmd/finalize/finalize.md
@@ -36,7 +36,7 @@ These settings control how finalize connects to the RabbitMQ message broker.
 
  - `BROKER_PASSWORD`: password to connect to rabbitmq
 
- - `BROKER_PREFETCHCOUNT`: Number of messagfes to pull from the message server at the time (default to 2)
+ - `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to 2)
 
 ### PostgreSQL Database settings:
 

--- a/cmd/finalize/finalize.md
+++ b/cmd/finalize/finalize.md
@@ -111,4 +111,4 @@ On error the service sleeps for up to 5 minutes to allow for database recovery, 
 
  - Finalize writes messages to one rabbitmq queue (default `backup`).
 
- - Finalize marks files as "ready" in the database using the `MarkReady` function.
+ - Finalize assigns the accesion ID to a file in the database using the `SetAccessionID` function.

--- a/cmd/ingest/ingest.md
+++ b/cmd/ingest/ingest.md
@@ -43,7 +43,7 @@ These settings control how ingest connects to the RabbitMQ message broker.
 
  - `BROKER_PASSWORD`: password to connect to rabbitmq
 
- - `BROKER_PREFETCHCOUNT`: Number of messagfes to pull from the message server at the time (default to 2)
+ - `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to 2)
 
 ### PostgreSQL Database settings:
 

--- a/cmd/intercept/intercept.go
+++ b/cmd/intercept/intercept.go
@@ -18,6 +18,8 @@ const (
 	msgCancel    string = "cancel"
 	msgIngest    string = "ingest"
 	msgMapping   string = "mapping"
+	msgRelease   string = "release"
+	msgDeprecate string = "deprecate"
 )
 
 func main() {
@@ -125,6 +127,8 @@ func main() {
 				msgAccession: "accessionIDs",
 				msgIngest:    "ingest",
 				msgMapping:   "mappings",
+				msgRelease:   "mappings",
+				msgDeprecate: "mappings",
 			}
 
 			routingKey := routing[msgType]
@@ -159,6 +163,8 @@ func schemaNameFromType(msgType string) (string, error) {
 		msgCancel:    "ingestion-trigger",
 		msgIngest:    "ingestion-trigger",
 		msgMapping:   "dataset-mapping",
+		msgRelease:   "dataset-release",
+		msgDeprecate: "dataset-deprecate",
 	}
 
 	if m[msgType] != "" {

--- a/cmd/mapper/mapper.go
+++ b/cmd/mapper/mapper.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 
 	"sda-pipeline/internal/broker"
 	"sda-pipeline/internal/config"
@@ -59,7 +60,23 @@ func main() {
 		}
 		for delivered := range messages {
 			log.Debugf("received a message: %s", delivered.Body)
-			err := mq.ValidateJSON(&delivered, "dataset-mapping", delivered.Body, &mappings)
+
+			schema, err := schemaFromDatasetOperation(delivered.Body)
+
+			if err != nil {
+				log.Errorf(err.Error())
+
+				if err := delivered.Ack(false); err != nil {
+					log.Errorf("failed to ack message: %v", err)
+				}
+				if err := mq.SendMessage(delivered.CorrelationId, mq.Conf.Exchange, conf.Broker.RoutingError, conf.Broker.Durable, delivered.Body); err != nil {
+					log.Errorf("failed to send error message: %v", err)
+				}
+
+				continue
+			}
+
+			err = mq.ValidateJSON(&delivered, schema, delivered.Body, &mappings)
 			if err != nil {
 				log.Errorf("Failed to validate message for work "+
 					"(corr-id: %s, "+
@@ -84,41 +101,109 @@ func main() {
 				continue
 			}
 
-			if err := db.MapFilesToDataset(mappings.DatasetID, mappings.AccessionIDs); err != nil {
-				log.Errorf("MapFilesToDataset failed  "+
-					"(corr-id: %s, "+
-					"datasetid: %s, "+
-					"accessionids: %v, "+
-					"error: %v)",
-					delivered.CorrelationId,
-					mappings.DatasetID,
-					mappings.AccessionIDs,
-					err)
+			switch mappings.Type {
+			case "mapping":
 
-				// Nack message so the server gets notified that something is wrong and requeue the message
-				if e := delivered.Nack(false, true); e != nil {
-					log.Errorf("Failed to nack message on mapping files to dataset) "+
+				log.Debug("Mapping type operation, mapping files to dataset")
+
+				if err := db.MapFilesToDataset(mappings.DatasetID, mappings.AccessionIDs); err != nil {
+					log.Errorf("MapFilesToDataset failed  "+
 						"(corr-id: %s, "+
 						"datasetid: %s, "+
-						"accessionid: %s, "+
-						"reason: %v)",
+						"accessionids: %v, "+
+						"error: %v)",
 						delivered.CorrelationId,
 						mappings.DatasetID,
 						mappings.AccessionIDs,
-						e)
+						err)
+
+					// Nack message so the server gets notified that something is wrong and requeue the message
+					if e := delivered.Nack(false, true); e != nil {
+						log.Errorf("Failed to nack message on mapping files to dataset) "+
+							"(corr-id: %s, "+
+							"datasetid: %s, "+
+							"accessionid: %s, "+
+							"reason: %v)",
+							delivered.CorrelationId,
+							mappings.DatasetID,
+							mappings.AccessionIDs,
+							e)
+					}
+
+					continue
 				}
 
-				continue
-			}
+				for _, aID := range mappings.AccessionIDs {
+					log.Infof("Mapped file to dataset "+
+						"(corr-id: %s, "+
+						"datasetid: %s, "+
+						"accessionid: %s)",
+						delivered.CorrelationId,
+						mappings.DatasetID,
+						aID)
+				}
+			case "release":
 
-			for _, aID := range mappings.AccessionIDs {
-				log.Infof("Mapped file to dataset "+
-					"(corr-id: %s, "+
-					"datasetid: %s, "+
-					"accessionid: %s)",
-					delivered.CorrelationId,
-					mappings.DatasetID,
-					aID)
+				log.Debug("Release type operation, marking files as ready")
+
+				if err := db.UpdateDatasetEvent(mappings.DatasetID, "ready", delivered.CorrelationId, "mapper"); err != nil {
+					log.Errorf("MarkReady failed  "+
+						"(corr-id: %s, "+
+						"datasetid: %s, "+
+						"accessionids: %v, "+
+						"error: %v)",
+						delivered.CorrelationId,
+						mappings.DatasetID,
+						mappings.AccessionIDs,
+						err)
+
+					// Nack message so the server gets notified that something is wrong and requeue the message
+					if e := delivered.Nack(false, true); e != nil {
+						log.Errorf("Failed to nack message on marking ready the files in the dataset) "+
+							"(corr-id: %s, "+
+							"datasetid: %s, "+
+							"accessionid: %s, "+
+							"reason: %v)",
+							delivered.CorrelationId,
+							mappings.DatasetID,
+							mappings.AccessionIDs,
+							e)
+					}
+
+					continue
+				}
+
+			case "deprecate":
+
+				log.Debug("Deprecate type operation, marking files as disabled")
+
+				// in the database this will translate to disabling of a file
+				if err := db.UpdateDatasetEvent(mappings.DatasetID, "disabled", delivered.CorrelationId, "mapper"); err != nil {
+					log.Errorf("MarkReady failed  "+
+						"(corr-id: %s, "+
+						"datasetid: %s, "+
+						"accessionids: %v, "+
+						"error: %v)",
+						delivered.CorrelationId,
+						mappings.DatasetID,
+						mappings.AccessionIDs,
+						err)
+
+					// Nack message so the server gets notified that something is wrong and requeue the message
+					if e := delivered.Nack(false, true); e != nil {
+						log.Errorf("Failed to nack message on marking ready the files in the dataset) "+
+							"(corr-id: %s, "+
+							"datasetid: %s, "+
+							"accessionid: %s, "+
+							"reason: %v)",
+							delivered.CorrelationId,
+							mappings.DatasetID,
+							mappings.AccessionIDs,
+							e)
+					}
+
+					continue
+				}
 			}
 
 			if err := delivered.Ack(false); err != nil {
@@ -136,4 +221,36 @@ func main() {
 	}()
 
 	<-forever
+}
+
+// schemaFromDatasetOperation returns the operation done with dataset
+// supplied in body of the message
+func schemaFromDatasetOperation(body []byte) (string, error) {
+	message := make(map[string]interface{})
+	err := json.Unmarshal(body, &message)
+	if err != nil {
+		return "", err
+	}
+
+	datasetMessageType, ok := message["type"]
+	if !ok {
+		return "", errors.New("Malformed message, dataset message type is missing")
+	}
+
+	datasetOpsType, ok := datasetMessageType.(string)
+	if !ok {
+		return "", errors.New("Could not cast operation attribute to string")
+	}
+
+	switch datasetOpsType {
+	case "mapping":
+		return "dataset-mapping", nil
+	case "release":
+		return "dataset-release", nil
+	case "deprecate":
+		return "dataset-deprecate", nil
+	default:
+		return "", errors.New("Could not recognize inbox operation")
+	}
+
 }

--- a/cmd/mapper/mapper.md
+++ b/cmd/mapper/mapper.md
@@ -33,7 +33,7 @@ These settings control how mapper connects to the RabbitMQ message broker.
 
  - `BROKER_PASSWORD`: password to connect to rabbitmq
 
- - `BROKER_PREFETCHCOUNT`: Number of messagfes to pull from the message server at the time (default to 2)
+ - `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to 2)
 
 ### PostgreSQL Database settings:
 

--- a/cmd/orchestrate/orchestrate.go
+++ b/cmd/orchestrate/orchestrate.go
@@ -379,7 +379,7 @@ func releaseMessage(body []byte, conf *config.Config) ([]byte, interface{}) {
 func validateMsg(delivered *amqp091.Delivery, mq *broker.AMQPBroker, routingKey string, durable bool, routingSchema string, publishMsg []byte, publishType interface{}) error {
 	err := mq.ValidateJSON(delivered, routingSchema, publishMsg, publishType)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	log.Debugf("Routing message (corr-id: %s, routingkey: %s, message: %s)",

--- a/cmd/orchestrate/orchestrate.go
+++ b/cmd/orchestrate/orchestrate.go
@@ -191,7 +191,7 @@ func processQueue(mq *broker.AMQPBroker, queue string, routingKey string, conf *
 				continue
 			}
 			// let us wait a minute before sending the release message
-			time.Sleep(1 * time.Minute)
+			time.Sleep(conf.Orchestrator.ReleaseDelay * time.Minute)
 			publishMsg, publishType = releaseMessage(delivered.Body, conf)
 			err = validateMsg(&delivered, mq, routingKey, durable, routingSchema, publishMsg, publishType)
 			if err != nil {

--- a/cmd/verify/verify.md
+++ b/cmd/verify/verify.md
@@ -42,7 +42,7 @@ These settings control how verify connects to the RabbitMQ message broker.
 
  - `BROKER_PASSWORD`: password to connect to rabbitmq
 
- - `BROKER_PREFETCHCOUNT`: Number of messagfes to pull from the message server at the time (default to 2)
+ - `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to 2)
 
 ### PostgreSQL Database settings:
 

--- a/dev_utils/compose-no-tls.yml
+++ b/dev_utils/compose-no-tls.yml
@@ -12,7 +12,7 @@ services:
       interval: 5s
       timeout: 20s
       retries: 3
-    image: ghcr.io/neicnordic/sda-db:v2.1.9
+    image: ghcr.io/neicnordic/sda-db:v2.1.11
     ports:
       - "5432:5432"
     volumes:

--- a/dev_utils/compose-sda-standalone.yml
+++ b/dev_utils/compose-sda-standalone.yml
@@ -35,7 +35,7 @@ services:
       interval: 5s
       timeout: 20s
       retries: 3
-    image: ghcr.io/neicnordic/sda-db:v2.1.9
+    image: ghcr.io/neicnordic/sda-db:v2.1.11
     ports:
       - "5432:5432"
     volumes:

--- a/dev_utils/compose-sda.yml
+++ b/dev_utils/compose-sda.yml
@@ -36,7 +36,7 @@ services:
       interval: 5s
       timeout: 20s
       retries: 3
-    image: ghcr.io/neicnordic/sda-db:v2.1.9
+    image: ghcr.io/neicnordic/sda-db:v2.1.11
     ports:
       - "5432:5432"
     volumes:

--- a/dev_utils/run_integration_test.sh
+++ b/dev_utils/run_integration_test.sh
@@ -105,6 +105,10 @@ curl --cacert certs/ca.pem -vvv -u test:test 'https://localhost:15672/api/exchan
 -H 'Content-Type: application/json;charset=UTF-8' \
 --data-binary '{"vhost":"test","name":"sda","properties":{"delivery_mode":2,"correlation_id":"1","content_encoding":"UTF-8","content_type":"application/json"},"routing_key":"files","payload_encoding":"string","payload":"{\"type\":\"mapping\",\"dataset_id\":\"EGAD00123456789\",\"accession_ids\":[\"EGAF00123456789\"]}"}'
 
+curl --cacert certs/ca.pem -vvv -u test:test 'https://localhost:15672/api/exchanges/test/sda/publish' \
+-H 'Content-Type: application/json;charset=UTF-8' \
+--data-binary '{"vhost":"test","name":"sda","properties":{"delivery_mode":2,"correlation_id":"1","content_encoding":"UTF-8","content_type":"application/json"},"routing_key":"files","payload_encoding":"string","payload":"{\"type\":\"release\",\"dataset_id\":\"EGAD00123456789\"}"}'
+
 dataset=$(docker run --rm --name client --network dev_utils_default -v "$PWD/certs:/certs" \
 	-e PGSSLCERT=/certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
 	neicnordic/pg-client:latest postgresql://lega_out:lega_out@db:5432/lega \

--- a/dev_utils/run_integration_test_no_tls.sh
+++ b/dev_utils/run_integration_test_no_tls.sh
@@ -103,6 +103,10 @@ curl -vvv -u test:test 'localhost:15672/api/exchanges/test/sda/publish' \
 -H 'Content-Type: application/json;charset=UTF-8' \
 --data-binary '{"vhost":"test","name":"sda","properties":{"delivery_mode":2,"correlation_id":"1","content_encoding":"UTF-8","content_type":"application/json"},"routing_key":"files","payload_encoding":"string","payload":"{\"type\":\"mapping\",\"dataset_id\":\"EGAD00123456789\",\"accession_ids\":[\"EGAF00123456789\"]}"}'
 
+curl -vvv -u test:test 'localhost:15672/api/exchanges/test/sda/publish' \
+-H 'Content-Type: application/json;charset=UTF-8' \
+--data-binary '{"vhost":"test","name":"sda","properties":{"delivery_mode":2,"correlation_id":"1","content_encoding":"UTF-8","content_type":"application/json"},"routing_key":"files","payload_encoding":"string","payload":"{\"type\":\"release\",\"dataset_id\":\"EGAD00123456789\"}"}'
+
 dataset=$(docker run --rm --name client --network dev_utils_default \
 neicnordic/pg-client:latest postgresql://lega_out:lega_out@db:5432/lega \
 -c "SELECT * from local_ega_ebi.file_dataset" | grep EGAD00123456789)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,6 +72,7 @@ type OrchestratorConf struct {
 	QueueMapping   string
 	QueueIngest    string
 	QueueAccession string
+	ReleaseDelay   time.Duration
 }
 
 // NewConfig initializes and parses the config file and/or environment using
@@ -501,6 +502,11 @@ func (c *Config) configSMTP() {
 // configOrchestrator provides the configuration for the standalone orchestator.
 func (c *Config) configOrchestrator() {
 	c.Orchestrator = OrchestratorConf{}
+	if viper.IsSet("broker.dataset.releasedelay") {
+		c.Orchestrator.ReleaseDelay = time.Duration(viper.GetInt("broker.dataset.releasedelay"))
+	} else {
+		c.Orchestrator.ReleaseDelay = 1
+	}
 	c.Orchestrator.ProjectFQDN = viper.GetString("project.fqdn")
 	if viper.IsSet("broker.queue.verified") {
 		c.Orchestrator.QueueVerify = viper.GetString("broker.queue.verified")

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -445,7 +445,8 @@ func (dbs *SQLdb) updateDatasetEvent(datasetID, status, correlationID, user stri
 
 }
 
-// SetAccessionID marks the file as "READY"
+// SetAccessionID adds a stable id to a file
+// identified by the user submitting it, inbox path and decrypted checksum
 func (dbs *SQLdb) SetAccessionID(accessionID, user, filepath, checksum string) error {
 
 	var err error
@@ -462,7 +463,8 @@ func (dbs *SQLdb) SetAccessionID(accessionID, user, filepath, checksum string) e
 	return err
 }
 
-// MarkReady marks the file as "READY"
+// setAccessionID (actual operation) adds a stable id to a file
+// identified by the user submitting it, inbox path and decrypted checksum
 func (dbs *SQLdb) setAccessionID(accessionID, user, filepath, checksum string) error {
 	dbs.checkAndReconnectIfNeeded()
 

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -400,6 +400,51 @@ func (dbs *SQLdb) checkAccessionIDExists(accessionID string) (bool, error) {
 	return false, nil
 }
 
+// UpdateDatasetEvent marks the files in a dataset as "ready" or "disabled"
+func (dbs *SQLdb) UpdateDatasetEvent(datasetID, status, correlationID, user string) error {
+
+	var err error
+
+	// 3, 9, 27, 81, 243 seconds between each retry event.
+	for count := 1; count <= dbRetryTimes; count++ {
+		err = dbs.updateDatasetEvent(datasetID, status, correlationID, user)
+		if err == nil {
+			break
+		}
+		time.Sleep(time.Duration(math.Pow(3, float64(count))) * time.Second)
+	}
+
+	return err
+}
+
+// updateDatasetEvent marks the files in a dataset as "ready" or "disabled"
+func (dbs *SQLdb) updateDatasetEvent(datasetID, status, correlationID, user string) error {
+	dbs.checkAndReconnectIfNeeded()
+
+	db := dbs.DB
+	const dataset = "SELECT id FROM sda.datasets WHERE stable_id = $1;"
+	const markFile = "INSERT INTO sda.file_event_log(file_id, event, correlation_id, user_id) " +
+		"SELECT file_id, $2, $3, $4 from sda.file_dataset " +
+		"WHERE dataset_id = $1;"
+
+	var datasetInternalID int
+	if err := db.QueryRow(dataset, datasetID).Scan(&datasetInternalID); err != nil {
+		return err
+	}
+
+	result, err := db.Exec(markFile, datasetInternalID, status, correlationID, user)
+	if err != nil {
+		return err
+	}
+
+	if rowsAffected, _ := result.RowsAffected(); rowsAffected == 0 {
+		return errors.New("something went wrong with the query zero rows were changed")
+	}
+
+	return nil
+
+}
+
 // SetAccessionID marks the file as "READY"
 func (dbs *SQLdb) SetAccessionID(accessionID, user, filepath, checksum string) error {
 
@@ -458,12 +503,18 @@ func (dbs *SQLdb) MapFilesToDataset(datasetID string, accessionIDs []string) err
 func (dbs *SQLdb) mapFilesToDataset(datasetID string, accessionIDs []string) error {
 	dbs.checkAndReconnectIfNeeded()
 
-	const getID = "SELECT file_id FROM local_ega.archive_files WHERE stable_id = $1"
-	const mapping = "INSERT INTO local_ega_ebi.filedataset (file_id, dataset_stable_id) " +
-		"VALUES ($1, $2) ON CONFLICT " +
+	const getID = "SELECT id FROM sda.files WHERE stable_id = $1;"
+	const dataset = "INSERT INTO sda.datasets (stable_id) VALUES ($1) " +
+		"ON CONFLICT DO NOTHING;"
+	const mapping = "INSERT INTO sda.file_dataset (file_id, dataset_id) " +
+		"SELECT $1, id FROM sda.datasets WHERE stable_id = $2 ON CONFLICT " +
 		"DO NOTHING;"
 	db := dbs.DB
-	var fileID int64
+	var fileID string
+	_, err := db.Exec(dataset, datasetID)
+	if err != nil {
+		return err
+	}
 	transaction, _ := db.Begin()
 	for _, accessionID := range accessionIDs {
 		err := db.QueryRow(getID, accessionID).Scan(&fileID)

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -400,14 +400,14 @@ func (dbs *SQLdb) checkAccessionIDExists(accessionID string) (bool, error) {
 	return false, nil
 }
 
-// MarkReady marks the file as "READY"
-func (dbs *SQLdb) MarkReady(accessionID, user, filepath, checksum string) error {
+// SetAccessionID marks the file as "READY"
+func (dbs *SQLdb) SetAccessionID(accessionID, user, filepath, checksum string) error {
 
 	var err error
 
 	// 3, 9, 27, 81, 243 seconds between each retry event.
 	for count := 1; count <= dbRetryTimes; count++ {
-		err = dbs.markReady(accessionID, user, filepath, checksum)
+		err = dbs.setAccessionID(accessionID, user, filepath, checksum)
 		if err == nil {
 			break
 		}
@@ -418,12 +418,12 @@ func (dbs *SQLdb) MarkReady(accessionID, user, filepath, checksum string) error 
 }
 
 // MarkReady marks the file as "READY"
-func (dbs *SQLdb) markReady(accessionID, user, filepath, checksum string) error {
+func (dbs *SQLdb) setAccessionID(accessionID, user, filepath, checksum string) error {
 	dbs.checkAndReconnectIfNeeded()
 
 	db := dbs.DB
 
-	const ready = "UPDATE local_ega.files SET status = 'READY', stable_id = $1 WHERE " +
+	const ready = "UPDATE local_ega.files SET stable_id = $1 WHERE " +
 		"elixir_id = $2 and inbox_path = $3 and decrypted_file_checksum = $4 and status = 'COMPLETED';"
 	result, err := db.Exec(ready, accessionID, user, filepath, checksum)
 	if err != nil {

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -402,12 +402,12 @@ func TestSetArchived(t *testing.T) {
 	log.SetOutput(os.Stdout)
 }
 
-func TestMarkReady(t *testing.T) {
+func TestSetAccessionID(t *testing.T) {
 	r := sqlTesterHelper(t, func(mock sqlmock.Sqlmock, testDb *SQLdb) error {
 
 		r := sqlmock.NewResult(10, 1)
 
-		mock.ExpectExec("UPDATE local_ega.files SET status = 'READY', "+
+		mock.ExpectExec("UPDATE local_ega.files SET "+
 			"stable_id = \\$1 WHERE "+
 			"elixir_id = \\$2 and "+
 			"inbox_path = \\$3 and "+
@@ -416,17 +416,17 @@ func TestMarkReady(t *testing.T) {
 			WithArgs("accessionId", "nobody", "/tmp/file.c4gh", "checksum").
 			WillReturnResult(r)
 
-		return testDb.MarkReady("accessionId", "nobody", "/tmp/file.c4gh", "checksum")
+		return testDb.SetAccessionID("accessionId", "nobody", "/tmp/file.c4gh", "checksum")
 	})
 
-	assert.Nil(t, r, "MarkReady failed unexpectedly")
+	assert.Nil(t, r, "setAccessionID failed unexpectedly")
 
 	var buf bytes.Buffer
 	log.SetOutput(&buf)
 
 	r = sqlTesterHelper(t, func(mock sqlmock.Sqlmock, testDb *SQLdb) error {
 
-		mock.ExpectExec("UPDATE local_ega.files SET status = 'READY', "+
+		mock.ExpectExec("UPDATE local_ega.files SET "+
 			"stable_id = \\$1 WHERE "+
 			"elixir_id = \\$2 and "+
 			"inbox_path = \\$3 and "+
@@ -435,13 +435,14 @@ func TestMarkReady(t *testing.T) {
 			WithArgs("accessionId", "nobody", "/tmp/file.c4gh", "checksum").
 			WillReturnError(fmt.Errorf("error for testing"))
 
-		return testDb.MarkReady("accessionId", "nobody", "/tmp/file.c4gh", "checksum")
+		return testDb.SetAccessionID("accessionId", "nobody", "/tmp/file.c4gh", "checksum")
 	})
 
-	assert.NotNil(t, r, "MarkReady did not fail as expected")
+	assert.NotNil(t, r, "SetAccessionID did not fail as expected")
 
 	log.SetOutput(os.Stdout)
 }
+
 func TestMapFilesToDataset(t *testing.T) {
 	r := sqlTesterHelper(t, func(mock sqlmock.Sqlmock, testDb *SQLdb) error {
 

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strconv"
 	"testing"
 	"time"
 
@@ -402,6 +401,53 @@ func TestSetArchived(t *testing.T) {
 	log.SetOutput(os.Stdout)
 }
 
+func TestUpdateDatasetEvent(t *testing.T) {
+	r := sqlTesterHelper(t, func(mock sqlmock.Sqlmock, testDb *SQLdb) error {
+		success := sqlmock.NewResult(1, 1)
+		r := sqlmock.NewRows([]string{"id"})
+
+		r.AddRow(1)
+
+		mock.ExpectQuery("SELECT id FROM sda.datasets WHERE stable_id = \\$1;").
+			WithArgs("datesetId").WillReturnRows(r)
+
+		mock.ExpectExec("INSERT INTO "+
+			"sda.file_event_log\\(file_id, event, correlation_id, user_id\\) "+
+			"SELECT file_id, \\$2, \\$3, \\$4 from sda.file_dataset "+
+			"WHERE dataset_id = \\$1;").
+			WithArgs(1, "ready", "somecorrelationid", "mapper").
+			WillReturnResult(success)
+
+		return testDb.UpdateDatasetEvent("datesetId", "ready", "somecorrelationid", "mapper")
+	})
+
+	assert.Nil(t, r, "UpdateDatasetEvent failed unexpectedly")
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+
+	r = sqlTesterHelper(t, func(mock sqlmock.Sqlmock, testDb *SQLdb) error {
+		r := sqlmock.NewRows([]string{"id"})
+
+		r.AddRow(1)
+
+		mock.ExpectQuery("SELECT id FROM sda.datasets WHERE stable_id = \\$1;").
+			WithArgs("datesetId").WillReturnRows(r)
+
+		mock.ExpectExec("INSERT INTO " +
+			"sda.file_event_log\\(file_id, event, correlation_id, user_id\\) " +
+			"SELECT file_id, \\$2, \\$3, \\$4 from sda.file_dataset " +
+			"WHERE dataset_id = \\$1;").
+			WillReturnError(fmt.Errorf("error for testing"))
+
+		return testDb.UpdateDatasetEvent("datesetId", "ready", "somecorrelationid", "mapper")
+	})
+
+	assert.NotNil(t, r, "UpdateDatasetEvent did not fail as expected")
+
+	log.SetOutput(os.Stdout)
+}
+
 func TestSetAccessionID(t *testing.T) {
 	r := sqlTesterHelper(t, func(mock sqlmock.Sqlmock, testDb *SQLdb) error {
 
@@ -447,7 +493,17 @@ func TestMapFilesToDataset(t *testing.T) {
 	r := sqlTesterHelper(t, func(mock sqlmock.Sqlmock, testDb *SQLdb) error {
 
 		// Set up a few file sets with different accession ids.
-		accessions := []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "0"}
+		// for the purpose of this test we consider accession ids the same as file ids
+		accessions := []string{"2f04d87f-0af6-4918-993f-437827f2ff8b",
+			"a5c477ff-b06b-4211-a978-a29aa86932b0",
+			"6bcd16b9-191f-46b8-92af-cef923c47206",
+			"35a7e68b-3062-4c91-b426-ca542313e4ce",
+			"e5b738ee-54c0-4128-854a-b4f055c907f4",
+			"98cddc6b-b836-41ab-8727-9beda6f4bdf",
+			"2eb6aa2c-047e-4ff1-bf70-2dbf8fa2bf11",
+			"a35836f4-8db4-4ad8-a389-ae1321120898",
+			"efb14df1-0f9e-4b39-a9c2-8c310b3d9935",
+			"9484d348-ce14-4a6b-a2b9-f73923f95fa0"}
 
 		diSet := map[string][]string{"dataset1": accessions[0:3],
 			"dataset2": accessions[4:5],
@@ -457,26 +513,30 @@ func TestMapFilesToDataset(t *testing.T) {
 		success := sqlmock.NewResult(1, 1)
 
 		for di, acs := range diSet {
+
+			mock.ExpectExec("INSERT INTO sda.datasets \\(stable_id\\) VALUES \\(\\$1\\) " +
+				"ON CONFLICT DO NOTHING;").
+				WithArgs(di).
+				WillReturnResult(success)
 			mock.ExpectBegin()
 			for _, aID := range acs {
-				r := sqlmock.NewRows([]string{"file_id"})
 
-				fileID, _ := strconv.Atoi(aID)
+				r := sqlmock.NewRows([]string{"id"})
 
-				r.AddRow(fileID)
+				// fileID, _ := strconv.Atoi(aID)
 
-				mock.ExpectQuery("SELECT file_id FROM local_ega.archive_files WHERE stable_id = \\$1").
+				r.AddRow(aID)
+
+				mock.ExpectQuery("SELECT id FROM sda.files WHERE stable_id = \\$1;").
 					WithArgs(aID).WillReturnRows(r)
 
-				mock.ExpectExec("INSERT INTO local_ega_ebi.filedataset "+
-					"\\(file_id, dataset_stable_id\\) VALUES \\(\\$1, \\$2\\) "+
-					"ON CONFLICT "+
-					"DO NOTHING;").
-					WithArgs(fileID, di).WillReturnResult(success)
+				mock.ExpectExec("INSERT INTO sda.file_dataset "+
+					"\\(file_id, dataset_id\\) SELECT \\$1, id FROM sda.datasets WHERE stable_id = \\$2 "+
+					"ON CONFLICT DO NOTHING;").
+					WithArgs(aID, di).WillReturnResult(success)
 
 			}
 			mock.ExpectCommit()
-
 			err := testDb.MapFilesToDataset(di, acs)
 
 			if !assert.Nil(t, err, "MapFilesToDataset failed unexpectedly") {
@@ -484,38 +544,36 @@ func TestMapFilesToDataset(t *testing.T) {
 			}
 		}
 
-		var buf bytes.Buffer
-		log.SetOutput(&buf)
+		// var buf bytes.Buffer
+		// log.SetOutput(&buf)
 
-		mock.ExpectBegin()
-		mock.ExpectQuery("SELECT file_id FROM local_ega.archive_files WHERE stable_id = \\$1").
-			WithArgs("aid1").WillReturnError(fmt.Errorf("error for testing"))
-		mock.ExpectRollback().WillReturnError(fmt.Errorf("error again"))
+		// mock.ExpectBegin()
+		// mock.ExpectQuery("SELECT id FROM sda.files WHERE stable_id = \\$1;").
+		// 	WithArgs("aid1").WillReturnError(fmt.Errorf("error for testing"))
+		// mock.ExpectRollback().WillReturnError(fmt.Errorf("error again"))
 
-		err := testDb.MapFilesToDataset("dataset", []string{"aid1"})
+		// err := testDb.MapFilesToDataset("dataset", []string{"aid1"})
 
-		assert.NotZero(t, buf.Len(), "Expected warning missing")
-		assert.NotNil(t, err, "MapFilesToDataset did not fail as expected")
+		// assert.NotZero(t, buf.Len(), "Expected warning missing")
+		// assert.NotNil(t, err, "MapFilesToDataset did not fail as expected")
 
-		buf.Reset()
+		// buf.Reset()
 
-		mock.ExpectBegin()
-		mock.ExpectQuery("SELECT file_id FROM local_ega.archive_files WHERE stable_id = \\$1").
-			WithArgs("aid1").WillReturnRows(sqlmock.NewRows([]string{"file_id"}).AddRow(100))
+		// mock.ExpectBegin()
+		// mock.ExpectQuery("SELECT id FROM sda.files WHERE stable_id = \\$1;").
+		// 	WithArgs("aid1").WillReturnRows(sqlmock.NewRows([]string{"file_id"}).AddRow(100))
 
-		mock.ExpectExec("INSERT INTO local_ega_ebi.filedataset "+
-			"\\(file_id, dataset_stable_id\\) "+
-			"VALUES \\(\\$1, \\$2\\) "+
-			"ON CONFLICT "+
-			"DO NOTHING;").
-			WithArgs(100, "dataset").WillReturnError(fmt.Errorf("error for testing"))
+		// mock.ExpectExec("INSERT INTO sda.file_dataset "+
+		// 	"\\(file_id, dataset_id\\) SELECT \\$1, id FROM sda.datasets WHERE stable_id = \\$2"+
+		// 	"ON CONFLICT DO NOTHING;").
+		// 	WithArgs(100, "dataset").WillReturnError(fmt.Errorf("error for testing"))
 
-		mock.ExpectRollback().WillReturnError(fmt.Errorf("error again"))
+		// mock.ExpectRollback().WillReturnError(fmt.Errorf("error again"))
 
-		err = testDb.MapFilesToDataset("dataset", []string{"aid1"})
+		// err = testDb.MapFilesToDataset("dataset", []string{"aid1"})
 
-		assert.NotZero(t, buf.Len(), "Expected warning missing")
-		assert.NotNil(t, err, "MapFilesToDataset did not fail as expected")
+		// assert.NotZero(t, buf.Len(), "Expected warning missing")
+		// assert.NotNil(t, err, "MapFilesToDataset did not fail as expected")
 
 		log.SetOutput(os.Stdout)
 

--- a/schemas/federated/dataset-deprecate.json
+++ b/schemas/federated/dataset-deprecate.json
@@ -1,0 +1,30 @@
+{
+    "title": "JSON schema for Local EGA dataset deprecation message interface",
+    "$id": "https://github.com/EGA-archive/LocalEGA/tree/master/schemas/dataset-deprecate.json",
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "type": "object",
+    "required": [
+        "type",
+        "dataset_id"
+    ],
+    "additionalProperties": true,
+    "properties": {
+        "type": {
+            "$id": "#/properties/type",
+            "type": "string",
+            "title": "The message type",
+            "description": "The message type",
+            "const": "deprecate"
+        },
+        "dataset_id": {
+            "$id": "#/properties/dataset_id",
+            "type": "string",
+            "title": "The Accession identifier for the dataset",
+            "description": "The Accession identifier for the dataset",
+            "pattern": "^EGAD[0-9]{11}$",
+            "examples": [
+                "EGAD12345678901"
+            ]
+        }
+    }
+}

--- a/schemas/federated/dataset-release.json
+++ b/schemas/federated/dataset-release.json
@@ -1,0 +1,30 @@
+{
+    "title": "JSON schema for Local EGA dataset release message interface",
+    "$id": "https://github.com/EGA-archive/LocalEGA/tree/master/schemas/dataset-release.json",
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "type": "object",
+    "required": [
+        "type",
+        "dataset_id"
+    ],
+    "additionalProperties": true,
+    "properties": {
+        "type": {
+            "$id": "#/properties/type",
+            "type": "string",
+            "title": "The message type",
+            "description": "The message type",
+            "const": "release"
+        },
+        "dataset_id": {
+            "$id": "#/properties/dataset_id",
+            "type": "string",
+            "title": "The Accession identifier for the dataset",
+            "description": "The Accession identifier for the dataset",
+            "pattern": "^EGAD[0-9]{11}$",
+            "examples": [
+                "EGAD12345678901"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
This will tag a new #minor version
This requires: https://github.com/neicnordic/sda-db/pull/91 and new `sda` schema, so **it breaks backwards compatibility with old db versions**

Introduces:
- `finalize` only adds the accessionId to the file, it does not mark it as `ready` anymore 
- `mapper` 
   - `mapping` message assigns files to dataset
   - `release` message marks `files` as `ready` in the db
   - `deprecate` message marks the files as `disabled` in the db, added integration test for disabled
- `orchestrate` send also the release message (right now it waits for 1 minute)

#### Mention

- other changes will come to `sda-orchestrator` (python version) and `sda-download` in different PRs
- ~last commit should be removed once db PR it is approved~